### PR TITLE
Fixes for iterative solver in parallel

### DIFF
--- a/src/molpro/linalg/array/DistrArrayFile.cpp
+++ b/src/molpro/linalg/array/DistrArrayFile.cpp
@@ -61,7 +61,7 @@ DistrArrayFile::DistrArrayFile(size_t dimension, MPI_Comm comm, const std::strin
 std::mutex s_open_error_mutex;
 DistrArrayFile::DistrArrayFile(std::unique_ptr<Distribution> distribution, MPI_Comm comm, const std::string& directory)
     : DistrArrayDisk(std::move(distribution), comm), m_directory(fs::absolute(fs::path(directory))),
-      m_filename(util::temp_file_name((fs::path(m_directory) / "DistrArrayFile-"), ".dat")),
+      m_filename(util::temp_file_name((fs::path(m_directory) / ("DistrArrayFile-"+std::to_string(molpro::mpi::rank_global()))), ".dat")),
       m_stream(std::make_unique<std::fstream>(m_filename.c_str(),
                                               std::ios::out | std::ios::binary | std::ios::trunc | std::ios::in)) {
   {

--- a/src/molpro/linalg/itsolv/helper-implementation.h
+++ b/src/molpro/linalg/itsolv/helper-implementation.h
@@ -432,6 +432,13 @@ void eigenproblem(std::vector<value_type>& eigenvectors, std::vector<value_type>
       //    molpro::cout << "new sorted eigenvalue "<<k<<", "<<ll<<", "<<eigval(ll)<<std::endl;
       //    molpro::cout << eigvec.col(ll)<<std::endl;
       subspaceEigenvectors.col(k) = eigvec.col(ll);
+      double maxcomp =0;
+      for (Eigen::Index l = 0; l < Hbar.cols(); l++) {
+          if (std::abs(subspaceEigenvectors.col(k)[l].real()) > std::abs(subspaceEigenvectors.col(k)[maxcomp].real()))
+              maxcomp = l;
+      }
+      if (subspaceEigenvectors.col(k)[maxcomp].real() < 0)
+          subspaceEigenvectors.col(k) = - subspaceEigenvectors.col(k);
     }
   }
 


### PR DESCRIPTION
- Force phases of eigenvectors of subspace, to avoid trouble with inconsistent phases on different MPI ranks
- Force DistrArrayFile file name to be unique in MPI communicator
Addresses https://github.com/molpro/molpro/issues/3516
