### PR TITLE
Don't pad error vector with artificial entries

### DIFF
--- a/src/molpro/linalg/itsolv/IterativeSolverTemplate.h
+++ b/src/molpro/linalg/itsolv/IterativeSolverTemplate.h
@@ -542,8 +542,6 @@ protected:
     prof->stop();
     set_value_errors();
     m_errors = m_subspace_solver->errors();
-    for (size_t i = m_errors.size(); i < n_roots(); ++i)
-      m_errors.push_back(1);
     m_working_set = detail::select_working_set(parameters.size(), m_errors, m_convergence_threshold, m_value_errors,
                                                m_convergence_threshold_value);
     for (size_t i = 0; i < m_working_set.size(); ++i) {


### PR DESCRIPTION
This padding, introduced in b3e7e830e464967dae54566825e57bfbe4d2b3ee could lead to the error vector being larger than the temp_solutions vector. In case the actual entries in the error vector (before padding) are all smaller than the padding value (1), select_working_set will select the indices of the padded entries into the working set. This will subsequently lead to out-of-bounds accesses on temp_solutions.

Since the purpose of this padding is not quite clear in the first place, this commit gets rid of it entirely.

Fixes #552