### PR TITLE
Make the build compatible with Eigen 5.x

### DIFF
--- a/src/molpro/linalg/CMakeLists.txt
+++ b/src/molpro/linalg/CMakeLists.txt
@@ -42,19 +42,30 @@ if (MKL_TYPE STREQUAL "lp64")
 endif ()
 
 if (NOT TARGET Eigen3::Eigen)
-    set(EIGEN_VERSION=3.4.0)
+    set(EIGEN_MIN_VERSION 3.4.0)
+    set(EIGEN_FETCH_TAG 3.4.0)
     message(VERBOSE "Eigen3::Eigen is not yet a target")
 
-    find_package(Eigen3 ${EIGEN_VERSION} QUIET)
+    # Note: no version arg to find_package — Eigen's ConfigVersion file uses
+    # strict-major-version compatibility, so a request for 3.4.0 rejects an
+    # installed 5.x. We accept anything Eigen3Config provides and validate
+    # the minimum version ourselves below.
+    find_package(Eigen3 QUIET)
 
-    if (EIGEN3_FOUND)
-        message(STATUS "Eigen3 (${Eigen3_VERSION})found on system: ${Eigen3_INCLUDE_DIRS}")
+    if ((Eigen3_FOUND OR EIGEN3_FOUND) AND Eigen3_VERSION VERSION_LESS ${EIGEN_MIN_VERSION})
+        message(STATUS "System Eigen3 ${Eigen3_VERSION} is older than required ${EIGEN_MIN_VERSION}; ignoring")
+        set(Eigen3_FOUND FALSE)
+        set(EIGEN3_FOUND FALSE)
+    endif ()
+
+    if (Eigen3_FOUND OR EIGEN3_FOUND)
+        message(STATUS "Eigen3 (${Eigen3_VERSION}) found on system: ${Eigen3_INCLUDE_DIRS}")
     else ()
         message(STATUS "Eigen3::Eigen not found on system, and will be downloaded")
         include(FetchContent)
         FetchContent_Declare(eigen3
                 GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-                GIT_TAG ${EIGEN_VERSION}
+                GIT_TAG ${EIGEN_FETCH_TAG}
                 )
         FetchContent_MakeAvailable(eigen3)
     endif ()
@@ -63,9 +74,6 @@ if (NOT TARGET Eigen3::Eigen)
     endif ()
 else ()
     message(STATUS "iterative-solver: Eigen3::Eigen target already defined")
-endif ()
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
-    set(EIGEN_DONT_VECTORIZE ON)
 endif ()
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
 message("CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}")

--- a/src/molpro/linalg/itsolv/helper-implementation.h
+++ b/src/molpro/linalg/itsolv/helper-implementation.h
@@ -17,8 +17,16 @@ template <typename value_type>
 std::list<SVD<value_type>> svd_eigen_jacobi(size_t nrows, size_t ncols, const array::Span<value_type>& m,
                                             double threshold) {
   auto mat = Eigen::Map<const Eigen::Matrix<value_type, Eigen::Dynamic, Eigen::Dynamic>>(m.data(), nrows, ncols);
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+  // Cast to unsigned int to avoid -Wdeprecated-enum-enum-conversion: the two
+  // Eigen flags belong to different enum types but are meant to be ORed here.
+  auto svd = Eigen::JacobiSVD<Eigen::Matrix<value_type, Eigen::Dynamic, Eigen::Dynamic>>(
+      mat, static_cast<unsigned int>(Eigen::ComputeThinV) |
+               static_cast<unsigned int>(Eigen::NoQRPreconditioner));
+#else
   auto svd = Eigen::JacobiSVD<Eigen::Matrix<value_type, Eigen::Dynamic, Eigen::Dynamic>, Eigen::NoQRPreconditioner>(
       mat, Eigen::ComputeThinV);
+#endif
   auto svd_system = std::list<SVD<value_type>>{};
   auto sv = svd.singularValues();
   for (int i = int(ncols) - 1; i >= 0; --i) {


### PR DESCRIPTION
## Summary

Fixes the build so it works against current Eigen3 (5.x series) in addition to the existing 3.4.x baseline. Three changes in one commit:

1. **Fix the typo `set(EIGEN_VERSION=3.4.0)` in `src/molpro/linalg/CMakeLists.txt`.** This created a CMake variable literally named `EIGEN_VERSION=3.4.0` with no value, so the intended 3.4.0 minimum-version pin was silently inert: `find_package(Eigen3 \${EIGEN_VERSION} QUIET)` carried no version constraint, and `GIT_TAG \${EIGEN_VERSION}` was empty in the FetchContent fallback (causing it to track the libeigen default branch). Replaced with `EIGEN_MIN_VERSION` and `EIGEN_FETCH_TAG`.

2. **Drop the minimum-version arg from `find_package(Eigen3)` and validate manually.** Eigen's `Eigen3ConfigVersion.cmake` uses strict-major-version compatibility (a request for `3.4.0` is treated as "3.4.x only"), so an installed Eigen 5.x is rejected when 3.4.0 is requested. Now we call `find_package(Eigen3 QUIET)` and gate on `Eigen3_VERSION VERSION_LESS \${EIGEN_MIN_VERSION}` ourselves. Also accept either `Eigen3_FOUND` (config mode) or `EIGEN3_FOUND` (legacy find-module mode).

3. **Update the `JacobiSVD` call site in `helper-implementation.h`.** The `Eigen::JacobiSVD<MatrixType, QRPreconditioner>` template signature was removed in Eigen 3.4.90+/5.x; the preconditioner is now a runtime bit in the options mask. The new form is selected behind `#if EIGEN_VERSION_AT_LEAST(3, 4, 90)`, with the OR operands cast to `unsigned int` to silence the C++20 `-Wdeprecated-enum-enum-conversion` warning that Eigen 5 itself triggers when combining its `DecompositionOptions` and `QRPreconditioners` enum types.

Also drops a dead `set(EIGEN_DONT_VECTORIZE ON)` line (a CMake variable that nothing reads — the matching `-DEIGEN_DONT_VECTORIZE` compile define already lives in the PGI branch a few lines below).

## Test plan

- [x] Configure picks up system Eigen 5.0.1 (`-- Eigen3 (5.0.1) found on system`) instead of falling back to the bundled 3.4.0.
- [x] Library builds clean with system Eigen 5.0.1, no deprecation warnings.
- [x] `test_svd_system.exe` passes against Eigen 5.0.1.
- [x] `test-iterative-solver-itsolv.exe` — 90 tests, all pass against Eigen 5.0.1.
- [ ] CI on the standard Eigen 3.4.0 path to confirm the `EIGEN_VERSION_AT_LEAST` guard still selects the old API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)