### PR TITLE
Build / CMake / CI hygiene + install fs.h unconditionally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ build011:
     - export MPIPROCS=2
     - BUILDTYPE=Release
     - BUILD=build/FORTRAN=0/MPI=1/PPIDD=1 ; mkdir -p $BUILD && cd $BUILD && pwd && time cmake -DCMAKE_BUILD_TYPE=${BUILDTYPE} -DFORTRAN=0 -DMPI=1 -DPPIDD=1 $OLDPWD && time cmake --build . -j2 && (time ctest || ctest -V)
-clang110:
+clang011:
   stage: test
   image: ${CI_REGISTRY_IMAGE}:latest
   #  tags:
@@ -115,7 +115,7 @@ clang110:
   script:
     - export MPIPROCS=2
     - BUILDTYPE=Release
-    - BUILD=build-clang/FORTRAN=1/MPI=1/PPIDD=0 ; mkdir -p $BUILD && cd $BUILD && pwd && CXX=clang++ cmake -DCMAKE_BUILD_TYPE=${BUILDTYPE} -DFORTRAN=0 -DMPI=1 -DPPIDD=1 $OLDPWD && time cmake --build . -j2 && (time ctest || ctest -V)
+    - BUILD=build-clang/FORTRAN=0/MPI=1/PPIDD=1 ; mkdir -p $BUILD && cd $BUILD && pwd && CXX=clang++ cmake -DCMAKE_BUILD_TYPE=${BUILDTYPE} -DFORTRAN=0 -DMPI=1 -DPPIDD=1 $OLDPWD && time cmake --build . -j2 && (time ctest || ctest -V)
 pages:
   stage: deploy
   image: ${CI_REGISTRY_IMAGE}:latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(LINEARALGEBRA_ARRAY_GA "Build with GA implementation of distributed array
 option(LINEARALGEBRA_ARRAY_HDF5 "Build with HDF5 implementation of distributed array" OFF)
 option(MPIFORTRAN "Build MPI fortran examples, using fortran MPI library" OFF)
 option(LIBRARY_ONLY "Build only the library" OFF)
+option(BENCHMARK "Build benchmark executables" OFF)
 option(VALGRIND "Run valgrind tests and examples" OFF)
 find_program(VALGRIND_EXISTS "valgrind")
 if (NOT VALGRIND_EXISTS)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,6 +11,6 @@ endforeach ()
 
 DependencyManagerDocs_Add(${PROJECT_NAME}
         FILES ../README.md LibraryDesign.md IterativeSolver.dox Arrays.dox ArrayHandlers.dox VecRef.dox
-        DOC_URL "https://molpro.github.io/iterative-solver/${CMAKE_PROJECT}"
+        DOC_URL "https://molpro.github.io/iterative-solver/${CMAKE_PROJECT_NAME}"
         DEPENDS profiler utilities # projects whose documentation has to be built before current project.
         )

--- a/src/molpro/linalg/CMakeLists.txt
+++ b/src/molpro/linalg/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Extra checking for HDF5 and global arrays will go here
 LibraryManager_Append(${PROJECT_NAME}
         SOURCES itsolv/IterativeSolver-double.cpp itsolv/IterativeSolver-complex-double.cpp options.cpp
-        PUBLIC_HEADER IterativeSolverC.h itsolv/helper.h itsolv/ArrayHandlers.h itsolv/Statistics.h options.h
-        PRIVATE_HEADER itsolv/helper-implementation.h
+        PUBLIC_HEADER IterativeSolverC.h itsolv/helper.h itsolv/helper-implementation.h itsolv/ArrayHandlers.h itsolv/Statistics.h options.h
         )
 if (FORTRAN)
     LibraryManager_Append(${PROJECT_NAME} SOURCES IterativeSolverF.F90 Iterative_Solver_Problem.F90 Iterative_Solver_PSpace.F90 Iterative_Solver_Matrix_Problem.F90)

--- a/src/molpro/linalg/array/CMakeLists.txt
+++ b/src/molpro/linalg/array/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 
 LibraryManager_Append(${PROJECT_NAME}
         SOURCES DistrArray.cpp DistrArrayDisk.cpp DistrArrayFile.cpp DistrArraySpan.cpp util.cpp
-        PUBLIC_HEADER DistrArray.h DistrArrayDisk.h DistrArrayFile.h DistrArraySpan.h util.h
+        PUBLIC_HEADER DistrArray.h DistrArrayDisk.h DistrArrayFile.h DistrArraySpan.h util.h ghc/filesystem.h
         )
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
@@ -52,7 +52,7 @@ if (MPI)
         message(STATUS "Building ${PROJECT_NAME} with MPI3 Array")
         target_compile_definitions(${PROJECT_NAME} PUBLIC LINEARALGEBRA_ARRAY_MPI3 LINEARALGEBRA_ARRAY_FILE)
         LibraryManager_Append(${PROJECT_NAME} SOURCES DistrArrayMPI3.cpp
-                PUBLIC_HEADER DistrArrayMPI3.h ghc/filesystem.h)
+                PUBLIC_HEADER DistrArrayMPI3.h)
     endif ()
 
     if (LINEARALGEBRA_ARRAY_GA)

--- a/src/molpro/linalg/array/util/CMakeLists.txt
+++ b/src/molpro/linalg/array/util/CMakeLists.txt
@@ -1,6 +1,6 @@
 LibraryManager_Append(${PROJECT_NAME}
         SOURCES temp_file.cpp
-        PUBLIC_HEADER Distribution.h select.h select_max_dot.h temp_file.h TempHandle.h gemm.h BufferManager.h)
+        PUBLIC_HEADER Distribution.h select.h select_max_dot.h temp_file.h TempHandle.h gemm.h BufferManager.h fs.h)
 
 if (LINEARALGEBRA_ARRAY_HDF5)
     LibraryManager_Append(${PROJECT_NAME}

--- a/src/molpro/linalg/itsolv/CMakeLists.txt
+++ b/src/molpro/linalg/itsolv/CMakeLists.txt
@@ -1,13 +1,13 @@
 LibraryManager_Append(${PROJECT_NAME}
-        SOURCES util.cpp Options.cpp LinearEigensystemDavidsonOptions.cpp LinearEquationsDavidsonOptions.cpp NonLinearEquationsDIISOptions.cpp OptimizeBFGSOptions.cpp OptimizeSDOptions.cpp LinearEigensystemRSPTOptions.cpp
-        PUBLIC_HEADER IterativeSolver.h IterativeSolverTemplate.h LinearEigensystemDavidson.h Options.h LinearEquationsDavidson.h LinearEigensystemRSPT.h
-        PUBLIC_HEADER IterativeSolver.h IterativeSolverTemplate.h LinearEigensystemDavidson.h OptimizeBFGS.h OptimizeSD.h Options.h LinearEquationsDavidson.h
-        Logger.h wrap.h wrap_util.h propose_rspace.h util.h DSpaceResetter.h LinearEigensystemDavidsonOptions.h CastOptions.h LinearEigensystemRSPTOptions.h
-        LinearEquationsDavidsonOptions.h SolverFactory.h SolverFactory-implementation.h options_map.h
-        OptimizeBFGSOptions.h OptimizeSDOptions.h
-        NonLinearEquationsDIISOptions.h
-        SOURCES Interpolate.cpp
-        PUBLIC_HEADER Interpolate.h
-        PUBLIC_HEADER helper-implementation.h
+        SOURCES util.cpp Options.cpp LinearEigensystemDavidsonOptions.cpp LinearEquationsDavidsonOptions.cpp
+        NonLinearEquationsDIISOptions.cpp OptimizeBFGSOptions.cpp OptimizeSDOptions.cpp LinearEigensystemRSPTOptions.cpp
+        Interpolate.cpp
+        PUBLIC_HEADER IterativeSolver.h IterativeSolverTemplate.h LinearEigensystemDavidson.h LinearEigensystemRSPT.h
+        LinearEquationsDavidson.h NonLinearEquationsDIIS.h OptimizeBFGS.h OptimizeSD.h Options.h
+        Logger.h wrap.h wrap_util.h propose_rspace.h util.h DSpaceResetter.h CastOptions.h
+        LinearEigensystemDavidsonOptions.h LinearEigensystemRSPTOptions.h LinearEquationsDavidsonOptions.h
+        NonLinearEquationsDIISOptions.h OptimizeBFGSOptions.h OptimizeSDOptions.h
+        SolverFactory.h SolverFactory-implementation.h options_map.h
+        Interpolate.h
         )
 add_subdirectory(subspace)

--- a/src/molpro/linalg/itsolv/subspace/CMakeLists.txt
+++ b/src/molpro/linalg/itsolv/subspace/CMakeLists.txt
@@ -1,4 +1,5 @@
 LibraryManager_Append(${PROJECT_NAME}
         PUBLIC_HEADER PSpace.h QSpace.h DSpace.h IXSpace.h Matrix.h SubspaceData.h ISubspaceSolver.h
-        gram_schmidt.h util.h XSpace.h Dimensions.h SubspaceSolverLinEig.h SubspaceSolverOptSD.h SubspaceSolverOptBFGS.h SubspaceSolverRSPT.h
+        gram_schmidt.h util.h XSpace.h Dimensions.h SubspaceSolverLinEig.h SubspaceSolverOptSD.h SubspaceSolverOptBFGS.h
+        SubspaceSolverDIIS.h SubspaceSolverRSPT.h
         )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(test-${PROJECT_NAME}-test test.cpp)
 target_link_libraries(test-${PROJECT_NAME}-test PUBLIC molpro::${PROJECT_NAME} gmock_main)
 gtest_discover_tests(test-${PROJECT_NAME}-test)
 if (VALGRIND)
-  add_test(valgrind-${PROJECT_NAME}-test valgrind --error-exitcode=1 --leak-check=full test-${PROJECT_TEST}-test)
+  add_test(valgrind-${PROJECT_NAME}-test valgrind --error-exitcode=1 --leak-check=full test-${PROJECT_NAME}-test)
 endif ()
 
 

--- a/test/array/CMakeLists.txt
+++ b/test/array/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
-foreach (fil empty_file inner_group_dataset.hdf5 single_dataset.hdf5)
-    configure_file("data/${fil}" "${CMAKE_CURRENT_BINARY_DIR}/data/${file}" COPYONLY)
+foreach (file empty_file inner_group_dataset.hdf5 single_dataset.hdf5)
+    configure_file("data/${file}" "${CMAKE_CURRENT_BINARY_DIR}/data/${file}" COPYONLY)
 endforeach ()
 if (LINEARALGEBRA_ARRAY_HDF5)
     add_executable(test-${PROJECT_NAME}-HDF5Handle.exe testHDF5Handle.cpp)


### PR DESCRIPTION
First of a series of small, focused PRs replacing the unwieldy #556 (which was hard to review and now conflicts heavily with master). Each PR in this series stands alone and can be reviewed independently.

## Commit 1 — Build / CMake / CI hygiene

* `test/CMakeLists.txt`: use `\${PROJECT_NAME}` (was undefined `\${PROJECT_TEST}`) for the valgrind test executable name.
* `test/array/CMakeLists.txt`: rename loop variable so the `configure_file` destination is not empty (was `\${file}` referenced under loop name `fil`).
* `doc/CMakeLists.txt`: use `\${CMAKE_PROJECT_NAME}` instead of undefined `\${CMAKE_PROJECT}` in `DOC_URL`.
* `CMakeLists.txt`: declare `BENCHMARK` option (was referenced unconditionally in `examples/CMakeLists.txt`).
* `src/molpro/linalg/itsolv/CMakeLists.txt`: consolidate the duplicated `SOURCES` / `PUBLIC_HEADER` keywords (a stray duplicate `SOURCES` block was silently shadowing entries), add `NonLinearEquationsDIIS.h` to the installed public headers, drop the duplicate `PUBLIC_HEADER` line for `helper-implementation.h`.
* `src/molpro/linalg/itsolv/subspace/CMakeLists.txt`: install `SubspaceSolverDIIS.h` (transitively required by `SolverFactory`).
* `src/molpro/linalg/CMakeLists.txt`: promote `helper-implementation.h` to `PUBLIC_HEADER` (it is included by public headers such as `QSpace.h`).
* `.gitlab-ci.yml`: rename `clang110` → `clang011` so the job name and `BUILD` path match the actual cmake flags (`FORTRAN=0 MPI=1 PPIDD=1`).

## Commit 2 — Install fs.h and ghc/filesystem.h unconditionally

`util/fs.h` is included from PUBLIC headers `DistrArrayFile.h` and `temp_file.h`, and falls back to `ghc/filesystem.h` when `std::filesystem` is unavailable. Neither was always installed:

* `fs.h` was not in any `PUBLIC_HEADER` list, so downstream consumers of `DistrArrayFile.h` / `temp_file.h` would fail to compile against an install.
* `ghc/filesystem.h` was only installed when `LINEARALGEBRA_ARRAY_MPI3` was on, so in serial / non-MPI3 builds the fallback target was missing.

Move `ghc/filesystem.h` to the always-installed group in `array/CMakeLists.txt` and add `fs.h` to `util/CMakeLists.txt`'s `PUBLIC_HEADER`.

## Test

Verified locally that the library builds cleanly with `-DMPI=ON -DLINEARALGEBRA_ARRAY_GA=OFF -DLINEARALGEBRA_ARRAY_HDF5=OFF`.

## Series context

Companion to #556 (will close once the series lands). Subsequent PRs in the series cover doc fixes, dead code removal, header hygiene, and per-component correctness patches. Each is rebased on current `master`.