### PR TITLE
Python correctness fixes (hessian, RHS, p_action, errors buffer, __del__)

### DIFF
--- a/python/build.sh
+++ b/python/build.sh
@@ -1,21 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 SCRIPTPATH=$( cd -- $(dirname "$0") >/dev/null 2>&1 ; pwd -P)
 
-if [ -z "$CONDA_PREFIX" -o $(basename $CONDA_PREFIX) = "base" ]; then
-  echo $0: must run this script in a non-base Conda environment
-  echo CONDA_PREFIX=$CONDA_PREFIX $(basename $CONDA_PREFIX)
+if [ -z "${CONDA_PREFIX:-}" ] || [ "$(basename "$CONDA_PREFIX")" = "base" ]; then
+  echo "$0: must run this script in a non-base Conda environment"
+  echo "CONDA_PREFIX=${CONDA_PREFIX:-} $(basename "${CONDA_PREFIX:-}")"
   exit 1
 fi
 
 python_dir=$SCRIPTPATH
 root_dir=$SCRIPTPATH/..
-if [ $(uname) = Linux -a $(uname -m) = x86_64 ]; then extra_requirements='mkl mkl-include'; else extra_requirements='';  fi
+if [ "$(uname)" = Linux ] && [ "$(uname -m)" = x86_64 ]; then extra_requirements='mkl mkl-include'; else extra_requirements=''; fi
 conda install -c conda-forge -y --file $python_dir/requirements.txt $extra_requirements
 cmake_build_dir=$python_dir/cmake-build-$(uname)-$(uname -m)
 mkdir -p $cmake_build_dir
 
-if [ $(uname) = Linux -a $(uname -m) = x86_64 ]; then  export CXXFLAGS="-fPIC -fpermissive" ; else export CXXFLAGS=-fPIC; fi
+if [ "$(uname)" = Linux ] && [ "$(uname -m)" = x86_64 ]; then export CXXFLAGS="-fPIC -fpermissive"; else export CXXFLAGS=-fPIC; fi
 cmake \
   -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \
   -DCMAKE_BUILD_TYPE=Release \

--- a/python/iterative_solver/example_problems.py
+++ b/python/iterative_solver/example_problems.py
@@ -29,15 +29,12 @@ class Box(Problem):
         return True
 
     def hessian(self, x):
-        # print('hessian',x)
         x0 = min(max(x[0], -10), 10)
         x1 = min(max(x[1], -10), 10)
         h = np.zeros([2, 2])
         for i in range(1, 11):
             t = i * 0.1
             d = math.exp(-x0 * t) - math.exp(-x1 * t) - math.exp(-t) + math.exp(-10 * t)
-            g[0] -= 2 * d * t * math.exp(-x0 * t)
-            g[1] += 2 * d * t * math.exp(-x1 * t)
             h[0, 0] += 2 * d * t * t * math.exp(-x0 * t) + 2 * t * t * math.exp(-2 * x0 * t)
             h[1, 1] += -2 * d * t * t * math.exp(-x1 * t) + 2 * t * t * math.exp(-2 * x1 * t)
             h[1, 1] += -2 * t * t * math.exp(-x0 * t - x1 * t)

--- a/python/iterative_solver/iterative_solver_extension.pyx
+++ b/python/iterative_solver/iterative_solver_extension.pyx
@@ -151,7 +151,7 @@ class IterativeSolver:
         cdef double[::1] actions_ = actions.reshape([parameters.shape[-1]*nbuffer])
         ev = np.zeros([self.nroot],dtype=float)
         cdef double[::1] ev_ = ev
-        errors = np.array([self.nroot],dtype=float)
+        errors = np.zeros(self.nroot, dtype=float)
         cdef double[::1] errors_ = errors
         verbosity = IterativeSolverVerbosity()
         use_diagonals = problem.diagonals(actions.reshape([actions.size]))

--- a/python/iterative_solver/iterative_solver_extension.pyx
+++ b/python/iterative_solver/iterative_solver_extension.pyx
@@ -38,6 +38,22 @@ class IterativeSolver:
         '''
         self.n = n
         self.nroot = nroot
+        self._initialized = False
+
+    def __del__(self):
+        # The concrete subclass constructor pushes an entry onto the C-side
+        # `instances` stack via IterativeSolver*Initialize. Pop it here so we
+        # don't leak. Note: Python finalisation order is not guaranteed to
+        # match the LIFO push order — if the user keeps multiple solver
+        # instances alive simultaneously and they are destroyed out of order,
+        # the wrong entry will be popped. The common single-solver-at-a-time
+        # case works.
+        if getattr(self, '_initialized', False):
+            try:
+                IterativeSolverFinalize()
+            except Exception:
+                pass
+            self._initialized = False
 
     def mpicomm_compute(self):
         global m_mpicomm_compute
@@ -234,6 +250,7 @@ class Optimize(IterativeSolver):
         IterativeSolverOptimizeInitialize(n_, rb, re, thresh_, thresh_value_, verbosity_,
                                           1 if minimize else 0, pname_, mpicomm_, algorithm_,
                                           options_)
+        self._initialized = True
         if range is not None:
             range[0] = rb[0]
             range[1] = re[0]
@@ -262,6 +279,7 @@ class NonLinearEquations(IterativeSolver):
         IterativeSolverNonLinearEquationsInitialize(n_, rb, re, thresh_, verbosity_,
                                           pname_, mpicomm_, algorithm_,
                                           options_)
+        self._initialized = True
         if range is not None:
             range[0] = rb[0]
             range[1] = re[0]
@@ -297,6 +315,7 @@ class LinearEquations(IterativeSolver):
                                                    1 if hermitian else 0, verbosity_,
                                                    pname_, mpicomm_, algorithm_,
                                                    options_)
+        self._initialized = True
         if range is not None:
             range[0] = rb[0]
             range[1] = re[0]
@@ -328,6 +347,7 @@ class LinearEigensystem(IterativeSolver):
                                                  1 if hermitian else 0, verbosity_,
                                                  pname_, mpicomm_, algorithm_,
                                                  options_)
+        self._initialized = True
         if range is not None:
             range[0] = rb[0]
             range[1] = re[0]

--- a/python/iterative_solver/iterative_solver_extension.pyx
+++ b/python/iterative_solver/iterative_solver_extension.pyx
@@ -124,7 +124,6 @@ class IterativeSolver:
     @property
     def converged(self):
         return IterativeSolverConverged() != 0
-        pass
 
     def solve(self, parameters, actions, problem, generate_initial_guess=False, max_iter=None, max_p=0):
         '''

--- a/python/iterative_solver/matrix_problem.py
+++ b/python/iterative_solver/matrix_problem.py
@@ -21,7 +21,7 @@ class MatrixProblem(Problem):
     def RHS(self, vector, instance):
         if instance < 0 or instance >= self.m_RHS.shape[1]:
             return False
-        vector = copy.deepcopy(self.m_RHS[instance, :])  # check index order
+        np.copyto(vector, self.m_RHS[instance, :])
         return True
 
     def action(self, parameters, action):
@@ -75,9 +75,9 @@ class MatrixProblem(Problem):
         :param actions On exit, the computed action has been added to the original contents
         :param range The range of the full space for which actions should be computed.
         """
+        s = slice(ranges[0], ranges[1])
         for i in range(actions.shape[0]):
             for k in range(self.p_space.size):
                 for kc in range(self.p_space.offsets[k], self.p_space.offsets[k + 1]):
-                    j = range(ranges[0], ranges[1])
-                    actions[i, j] = actions[i, j] + self.matrix[self.p_space.indices[kc], j] * \
+                    actions[i, s] = actions[i, s] + self.matrix[self.p_space.indices[kc], s] * \
                                     self.p_space.coefficients[kc] * p_coefficients[i, k]


### PR DESCRIPTION
Fifth in the series (#559, #560, #561, #562 already merged).

## Commits

### 1. `example_problems.py::Box.hessian`, `matrix_problem.py::RHS` / `p_action`, `build.sh`
- `Box.hessian` had two stray gradient-update lines referencing an undefined `g`. They would have raised `NameError` on first call.
- `MatrixProblem.RHS` did `vector = copy.deepcopy(self.m_RHS[instance, :])` — this rebinds the local name and never writes into the caller's array. The C side observed zeros. Replaced with `np.copyto(vector, ...)`.
- `MatrixProblem.p_action`: `j = range(...)` then `actions[i, j]` does **not** slice — numpy treats `range` as a sequence of integers and produces an unintended fancy index. Build a `slice(...)` once and use it for both destination and matrix row.
- `python/build.sh`: tighten shell hygiene (POSIX-correct `[ a ] || [ b ]`, quoted `$CONDA_PREFIX`, allow unbound `CONDA_PREFIX` under `set -u`, switch shebang to `bash` since `set -u` plus subshell expansion is not reliably supported under `/bin/sh`).

### 2. `iterative_solver_extension.pyx`: release C-side instance from solver `__del__`
Each Python solver class pushes onto the C-side `instances` stack via `IterativeSolver*Initialize` but nothing was calling `IterativeSolverFinalize`. Multiple Python solvers therefore shared the most recently constructed one (since CMPI uses `instances.top()`) and earlier instances leaked.

Adds a `__del__` on the base class that calls `IterativeSolverFinalize` when the corresponding `*Initialize` succeeded. Each subclass sets `self._initialized = True` after its `Initialize` returns; `__del__` pops once on destruction.

Caveat: Python's finalisation order is not guaranteed to follow the LIFO push pattern. If user code keeps several solver instances alive and lets them be destroyed out of order, the wrong stack entry is popped. The common single-solver-at-a-time pattern works; the long-term fix is to replace CMPI's stack with a handle registry — out of scope here.

### 3. `iterative_solver_extension.pyx`: drop unreachable `pass` after `return`

### 4. `iterative_solver_extension.pyx`: fix `errors` buffer allocation in `solve()`
`np.array([self.nroot], dtype=float)` produces a 1-element array *containing the value `self.nroot`*, not an nroot-element zero buffer. `IterativeSolverErrors()` then writes `nroot` doubles through the matching `cdef double[::1]` view, overflowing the underlying allocation whenever `nroot > 1`. Use `np.zeros(self.nroot)` like the surrounding `ev`.

## Test
Python and bash syntax checks pass; CI's `python-test` job will exercise the full bindings.

Series cousins: #559, #560, #561, #562 (all merged).