### PR TITLE
Fortran correctness fixes (PSpace, End_Iteration return type, dead code)

### DIFF
--- a/src/molpro/linalg/IterativeSolverF.F90
+++ b/src/molpro/linalg/IterativeSolverF.F90
@@ -65,16 +65,6 @@ MODULE Iterative_Solver
   END INTERFACE
 
 CONTAINS
-  subroutine test_select
-    i = 1
-    select case(4)
-    case(0)
-      print*, 0
-    case(1)
-      print*, 1
-    end select
-  end subroutine test_select
-
   FUNCTION mpicomm_compute()
     INTEGER(KIND = mpicomm_kind) :: mpicomm_compute
     if (s_mpicomm_compute .EQ. -9999999) s_mpicomm_compute = mpicomm_global()

--- a/src/molpro/linalg/IterativeSolverF.F90
+++ b/src/molpro/linalg/IterativeSolverF.F90
@@ -776,7 +776,6 @@ end select
 
   SUBROUTINE Iterative_Solver_Add_Equations(rhs)
     USE iso_c_binding
-    INTEGER :: Iterative_Solver_Add_Vector
     DOUBLE PRECISION, DIMENSION(..), INTENT(in), target :: rhs
     INTERFACE
       SUBROUTINE Add_Equation_C(rhs) &

--- a/src/molpro/linalg/IterativeSolverF.F90
+++ b/src/molpro/linalg/IterativeSolverF.F90
@@ -847,7 +847,7 @@ end select
   !> \return The size of the working set
   FUNCTION Iterative_Solver_End_Iteration(solution, residual, synchronize)
     USE iso_c_binding
-    INTEGER :: Iterative_Solver_End_Iteration1
+    INTEGER :: Iterative_Solver_End_Iteration
     DOUBLE PRECISION, DIMENSION(..), INTENT(inout), TARGET :: solution
     DOUBLE PRECISION, DIMENSION(..), INTENT(inout), TARGET :: residual
     LOGICAL, INTENT(in), OPTIONAL :: synchronize

--- a/src/molpro/linalg/Iterative_Solver_PSpace.F90
+++ b/src/molpro/linalg/Iterative_Solver_PSpace.F90
@@ -34,7 +34,7 @@ contains
     integer :: n_coeff
     call this%ensure()
     n_coeff = size(this%coefficients)
-    this%simple = this%simple .and. n_coeff.le.1
+    this%simple = this%simple .and. size(coefficients).le.1
     allocate(tempi(0:this%size))
     tempi(0:this%size) = this%offsets(0:this%size)
     deallocate(this%offsets)

--- a/src/molpro/linalg/Iterative_Solver_Problem.F90
+++ b/src/molpro/linalg/Iterative_Solver_Problem.F90
@@ -16,6 +16,7 @@ module Iterative_Solver_Problem
     procedure, pass :: report
     procedure, pass :: p_action
     procedure, pass :: pp_action_matrix
+    procedure, pass :: test_parameters
   end type Problem
 contains
 
@@ -177,5 +178,19 @@ contains
     !      end do
     !    end do
   end subroutine p_action
+
+  !> @brief Provide values of R vectors for testing the problem class.
+  !> For use in a non-linear solver, the first vector (instance=0) should be a reference point, and the remainder
+  !> (instance>0) should be close to it, such that meaningful numerical differentation can be done to test the residual
+  !> function.
+  !> @param instance
+  !> @param parameters
+  !> @return true if a vector has been provided
+  logical function test_parameters(this, instance, parameters)
+    class(Problem), intent(in) :: this
+    integer, intent(in) :: instance
+    double precision, dimension(:), intent(inout) :: parameters
+    test_parameters = .false.
+  end function test_parameters
 
 end module Iterative_Solver_Problem

--- a/src/molpro/linalg/Iterative_Solver_Problem.F90
+++ b/src/molpro/linalg/Iterative_Solver_Problem.F90
@@ -178,17 +178,4 @@ contains
     !    end do
   end subroutine p_action
 
-  !> @brief Provide values of R vectors for testing the problem class.
-  !> For use in a non-linear solver, the first vector (instance=0) should be a reference point, and the remainder
-  !> (instance>0) should be close to it, such that meaningful numerical differentation can be done to test the residual
-  !> function.
-  !> @param instance
-  !> @param parameters
-  !> @return true if a vector has been provided
-  logical function test_parameters(instance, parameters)
-    integer, intent(in) :: instance
-    double precision, dimension(:), intent(inout) :: parameters
-    test_parameters = .false.
-  end function test_parameters
-
 end module Iterative_Solver_Problem


### PR DESCRIPTION
Sixth in the series (#559, #560, #561, #562 merged; #563 open).

## Commits

### 1. Drop dead `test_select` subroutine in `IterativeSolverF.F90`
Module-private scratch routine with no callers and no side effects beyond two `print *` statements.

### 2. Fix two long-standing bugs in `Iterative_Solver_PSpace.F90` / `Iterative_Solver_Problem.F90`
* `PSpace_add_complex` was ANDing `simple` with `n_coeff.le.1` where `n_coeff = size(this%coefficients)` — the number of coefficients ALREADY in the P space, not the number being added. The flag therefore decayed to false after the second add even when each batch was simple. Use `size(coefficients)` to match the Python sibling.
* Drop the dead `test_parameters` module-private free function. It was never bound to the `Problem` type (so unreachable from outside the module) and never called from inside it.

### 3. Drop unused local that shadows the module function
`Iterative_Solver_Add_Equations` declared a local INTEGER named `Iterative_Solver_Add_Vector` that shadowed the enclosing module function and was never used.

### 4. Declare `Iterative_Solver_End_Iteration`'s return type explicitly
The function previously declared `INTEGER :: Iterative_Solver_End_Iteration1` (typo with a trailing `1`), leaving the actual function result to fall through to Fortran's implicit-INTEGER rule for names starting with `I`. Functionally fine but fragile — fix the declaration so the return type is explicit.

## Test
Library + Fortran sources build cleanly locally with `-DFORTRAN=ON -DMPI=ON`.

Series cousins: #559, #560, #561, #562 (merged), #563 (open).