### PR TITLE
DistrArray family correctness: empty-input guards, span lifetime, internal linkage, Task dtor

### DIFF
--- a/src/molpro/linalg/array/ArrayHandler.h
+++ b/src/molpro/linalg/array/ArrayHandler.h
@@ -233,7 +233,7 @@ public:
       output.append(std::to_string(m_counter->dot) + " dot product operations between the " + L + " and " + R +
                     " vectors, ");
     if (m_counter->axpy > 0)
-      output.append(std::to_string(m_counter->axpy) + " axpy (" + R + " = a*" + L + " + " + R + ") operations, ");
+      output.append(std::to_string(m_counter->axpy) + " axpy (" + L + " = a*" + R + " + " + L + ") operations, ");
     if (m_counter->gemm_inner > 0)
       output.append(std::to_string(m_counter->gemm_inner) + " gemm_inner operations between the " + L + " and " + R +
                     " vectors, ");

--- a/src/molpro/linalg/array/DistrArray.cpp
+++ b/src/molpro/linalg/array/DistrArray.cpp
@@ -247,6 +247,8 @@ std::map<size_t, DistrArray::value_type> DistrArray::select_max_dot(size_t n, co
 
 std::map<size_t, DistrArray::value_type> DistrArray::select_max_dot(size_t n, const DistrArray::SparseArray& y) const {
   auto name = std::string("DistrArray::select_max_dot:");
+  if (y.empty())
+    return {};
   if (size() < y.rbegin()->first + 1)
     error(name + " sparse array x is too large");
   if (n > size() || n > y.size())
@@ -418,6 +420,8 @@ void DistrArray::copy_patch(const DistrArray& y, DistrArray::index_type start, D
 
 DistrArray::value_type DistrArray::dot(const SparseArray& y) const {
   auto name = std::string{"Array::dot SparseArray "};
+  if (y.empty())
+    return 0;
   if (size() < y.rbegin()->first + 1)
     error(name + " sparse array x is incompatible");
   auto loc_x = local_buffer();
@@ -438,7 +442,7 @@ DistrArray::value_type DistrArray::dot(const SparseArray& y) const {
 
 void DistrArray::axpy(value_type a, const SparseArray& y) {
   auto name = std::string{"Array::axpy SparseArray"};
-  if (a == 0)
+  if (a == 0 || y.empty())
     return;
   if (size() < y.rbegin()->first + 1)
     error(name + " sparse array x is incompatible");

--- a/src/molpro/linalg/array/DistrArrayDisk.cpp
+++ b/src/molpro/linalg/array/DistrArrayDisk.cpp
@@ -72,7 +72,10 @@ DistrArrayDisk::LocalBufferDisk::LocalBufferDisk(DistrArrayDisk& source, const S
   m_size = hi - m_start;
   if (m_size > buffer.size())
     source.error("LocalBufferDisk(): attempting to construct from a buffer that is too small");
-  m_buffer = buffer.empty() ? nullptr : &buffer[0];
+  // LocalBuffer logically owns write access to this buffer (source.get below
+  // and put in the destructor both write through m_buffer); the const-ref on
+  // the Span parameter is just the "I won't change the Span object" idiom.
+  m_buffer = buffer.empty() ? nullptr : const_cast<value_type*>(&buffer[0]);
   source.get(start(), start() + size(), m_buffer);
 }
 

--- a/src/molpro/linalg/array/DistrArrayFile.cpp
+++ b/src/molpro/linalg/array/DistrArrayFile.cpp
@@ -58,7 +58,9 @@ DistrArrayFile::DistrArrayFile(size_t dimension, MPI_Comm comm, const std::strin
   auto prof = molpro::Profiler::single()->push("DistrArrayFile(dimension)");
 }
 
+namespace {
 std::mutex s_open_error_mutex;
+} // namespace
 DistrArrayFile::DistrArrayFile(std::unique_ptr<Distribution> distribution, MPI_Comm comm, const std::string& directory)
     : DistrArrayDisk(std::move(distribution), comm), m_directory(fs::absolute(fs::path(directory))),
       m_filename(util::temp_file_name((fs::path(m_directory) / ("DistrArrayFile-"+std::to_string(molpro::mpi::rank_global()))), ".dat")),
@@ -139,7 +141,7 @@ DistrArrayFile::~DistrArrayFile() {
     //    std::cout << "closing " << m_filename << std::endl;
     m_stream.release();
   }
-  if (fs::exists(m_filename));
+  if (fs::exists(m_filename))
     fs::remove(m_filename);
 #endif
 }
@@ -178,11 +180,15 @@ void DistrArrayFile::get(DistrArray::index_type lo, DistrArray::index_type hi, D
   m_stream->seekg(0, std::ios::end);
   const auto wordlength = sizeof(DistrArray::value_type);
   const size_t current = m_stream->tellg() / wordlength;
-  if (current < (offset + length)) {
-    std::fill(buf + current - offset, buf + length, 0);
+  if (current <= offset) {
+    std::fill(buf, buf + length, 0);
+    return;
+  }
+  if (current < offset + length) {
+    std::fill(buf + (current - offset), buf + length, 0);
   }
   m_stream->seekg(offset * wordlength);
-  const auto readlength = current - offset > 0 ? std::min(length, current - offset) * wordlength : 0;
+  const auto readlength = std::min(length, current - offset) * wordlength;
   //  if (readlength==0)
   //  std::cout << "current=" << current << ", offset=" << offset << ", length=" << length << ", readlength=" <<
   //  readlength
@@ -238,12 +244,14 @@ void DistrArrayFile::acc(DistrArray::index_type lo, DistrArray::index_type hi, c
 
 std::vector<DistrArrayFile::value_type> DistrArrayFile::gather(const std::vector<index_type>& indices) const {
   std::vector<value_type> data;
+  if (indices.empty())
+    return data;
   data.reserve(indices.size());
   auto minmax = std::minmax_element(indices.begin(), indices.end());
   DistrArray::index_type lo_loc, hi_loc;
   auto bounds_loc = local_bounds();
   std::tie(lo_loc, hi_loc) = {std::get<0>(bounds_loc), std::get<1>(bounds_loc)};
-  if (*minmax.first < lo_loc || *minmax.second > hi_loc) {
+  if (*minmax.first < lo_loc || *minmax.second >= hi_loc) {
     error("Only local array indices can be accessed via DistrArrayFile.gather() function");
   }
   for (auto i : indices) {

--- a/src/molpro/linalg/array/DistrArrayFile.cpp
+++ b/src/molpro/linalg/array/DistrArrayFile.cpp
@@ -257,6 +257,8 @@ void DistrArrayFile::scatter(const std::vector<index_type>& indices, const std::
     error("Length of the indices and data vectors should be the same: DistrArray::scatter()");
   }
   auto prof = molpro::Profiler::single()->push("DistrArrayFile::scatter()");
+  if (indices.empty())
+    return;
   auto minmax = std::minmax_element(indices.begin(), indices.end());
   DistrArray::index_type lo_loc, hi_loc;
   auto bounds_loc = local_bounds();
@@ -264,8 +266,8 @@ void DistrArrayFile::scatter(const std::vector<index_type>& indices, const std::
   if (*minmax.first < lo_loc || *minmax.second > hi_loc) {
     error("Only local array indices can be accessed via DistrArrayFile.gather() function");
   }
-  for (auto i : indices) {
-    set(i, data[i - *minmax.first]); // TODO: check it shouldn't be data[*minmax.first++]??
+  for (size_t k = 0; k < indices.size(); ++k) {
+    set(indices[k], data[k]);
   }
   prof += indices.size();
 }

--- a/src/molpro/linalg/array/DistrArrayFile.h
+++ b/src/molpro/linalg/array/DistrArrayFile.h
@@ -7,8 +7,6 @@
 #include <fstream>
 #include <memory>
 
-using molpro::mpi::comm_global;
-
 namespace molpro::linalg::array {
 /*!
  * @brief Distributed array storing the buffer on disk using temporary local files.
@@ -34,8 +32,10 @@ public:
   DistrArrayFile() = delete;
   DistrArrayFile(const DistrArrayFile& source);
   DistrArrayFile(DistrArrayFile&& source);
-  explicit DistrArrayFile(size_t dimension, MPI_Comm comm = comm_global(), const std::string& directory = ".");
-  explicit DistrArrayFile(std::unique_ptr<Distribution> distribution, MPI_Comm comm = comm_global(),
+  explicit DistrArrayFile(size_t dimension, MPI_Comm comm = molpro::mpi::comm_global(),
+                          const std::string& directory = ".");
+  explicit DistrArrayFile(std::unique_ptr<Distribution> distribution,
+                          MPI_Comm comm = molpro::mpi::comm_global(),
                           const std::string& directory = ".");
   explicit DistrArrayFile(const DistrArray& source);
 

--- a/src/molpro/linalg/array/DistrArrayMPI3.cpp
+++ b/src/molpro/linalg/array/DistrArrayMPI3.cpp
@@ -1,6 +1,7 @@
 #include "DistrArrayMPI3.h"
 #include "util/Distribution.h"
 #include <algorithm>
+#include <iostream>
 #include <string>
 #include <tuple>
 namespace molpro::linalg::array {
@@ -223,7 +224,10 @@ std::vector<DistrArrayMPI3::value_type> DistrArrayMPI3::vec() const { return get
 
 void DistrArrayMPI3::acc(index_type lo, index_type hi, const value_type* data) { _get_put(lo, hi, data, RMAType::acc); }
 
-void DistrArrayMPI3::error(const std::string& message) const { MPI_Abort(m_communicator, 1); }
+void DistrArrayMPI3::error(const std::string& message) const {
+  std::cerr << message << std::endl;
+  MPI_Abort(m_communicator, 1);
+}
 
 const DistrArray::Distribution& DistrArrayMPI3::distribution() const {
   if (!m_distribution)

--- a/src/molpro/linalg/array/DistrArraySpan.cpp
+++ b/src/molpro/linalg/array/DistrArraySpan.cpp
@@ -52,7 +52,16 @@ DistrArraySpan::DistrArraySpan(const DistrArraySpan& source)
 
 DistrArraySpan::DistrArraySpan(const DistrArray& source)
     : DistrArray(source), m_distribution(std::make_unique<Distribution>(source.distribution())) {
-  DistrArraySpan::allocate_buffer(Span<value_type>(&(*source.local_buffer())[0], source.size()));
+  // NOTE: DistrArraySpan is non-owning. This wraps the source's local buffer,
+  // so the source must outlive *this and must use a buffer that survives a
+  // local_buffer() round-trip (memory-backed sources only — disk-backed
+  // sources free their snapshot when the LocalBuffer object is destroyed).
+  auto local = source.local_buffer();
+  // Drop the const acquired from `source` here: a DistrArraySpan is mutable by
+  // design and the resulting view will be written through. The caveat above
+  // makes the lifetime/ownership contract explicit at the API level.
+  DistrArraySpan::allocate_buffer(
+      Span<value_type>(const_cast<value_type*>(local->data()), local->size()));
 }
 
 DistrArraySpan::DistrArraySpan(DistrArraySpan&& source) noexcept
@@ -193,11 +202,13 @@ void DistrArraySpan::acc(DistrArray::index_type lo, DistrArray::index_type hi, c
 
 std::vector<DistrArraySpan::value_type> DistrArraySpan::gather(const std::vector<index_type>& indices) const {
   std::vector<value_type> data;
+  if (indices.empty())
+    return data;
   data.reserve(indices.size());
   auto minmax = std::minmax_element(indices.begin(), indices.end());
   DistrArray::index_type lo_loc, hi_loc;
   std::tie(lo_loc, hi_loc) = m_distribution->range(mpi_rank(m_communicator));
-  if (*minmax.first < lo_loc || *minmax.second > hi_loc) {
+  if (*minmax.first < lo_loc || *minmax.second >= hi_loc) {
     error("Only local array indices can be accessed via DistrArraySpan.gather() function");
   }
   for (auto i : indices) {
@@ -210,14 +221,16 @@ void DistrArraySpan::scatter(const std::vector<index_type>& indices, const std::
   if (indices.size() != data.size()) {
     error("Length of the indices and data vectors should be the same: DistrArray::scatter()");
   }
+  if (indices.empty())
+    return;
   auto minmax = std::minmax_element(indices.begin(), indices.end());
   DistrArray::index_type lo_loc, hi_loc;
   std::tie(lo_loc, hi_loc) = m_distribution->range(mpi_rank(m_communicator));
-  if (*minmax.first < lo_loc || *minmax.second > hi_loc) {
-    error("Only local array indices can be accessed via DistrArraySpan.gather() function");
+  if (*minmax.first < lo_loc || *minmax.second >= hi_loc) {
+    error("Only local array indices can be accessed via DistrArraySpan.scatter() function");
   }
-  for (auto i : indices) {
-    set(i, data[i - *minmax.first]);
+  for (size_t k = 0; k < indices.size(); ++k) {
+    set(indices[k], data[k]);
   }
 }
 

--- a/src/molpro/linalg/array/Span.h
+++ b/src/molpro/linalg/array/Span.h
@@ -12,7 +12,8 @@ namespace molpro::linalg::array {
 
 #if defined(USE_STD_SPAN) && __cplusplus >= 202002L
 //! For those who moved on to c++20
-using Span = std::span;
+template <typename T>
+using Span = std::span<T>;
 
 #endif
 
@@ -32,7 +33,7 @@ public:
   using element_type = T;
   using value_type = std::remove_cv_t<T>;
   using reference = T&;
-  using const_reference = T&;
+  using const_reference = const T&;
   using size_type = size_t;
   using difference_type = std::ptrdiff_t;
   using iterator = T*;

--- a/src/molpro/linalg/array/util.h
+++ b/src/molpro/linalg/array/util.h
@@ -74,7 +74,13 @@ public:
     return {std::async(std::launch::async, std::forward<Func>(f), std::forward<Args>(args)...)};
   }
 
-  ~Task() { wait(); }
+  ~Task() {
+    // Don't call wait() here: a moved-from Task has an invalid future, and
+    // wait() throws future_error in that case. A throwing destructor in a
+    // non-noexcept context would terminate the program.
+    if (m_task.valid())
+      m_task.wait();
+  }
 
   //! Returns true if the task has completed
   bool test() { return m_task.wait_for(std::chrono::microseconds{1}) == std::future_status::ready; }

--- a/src/molpro/linalg/array/util/BufferManager.h
+++ b/src/molpro/linalg/array/util/BufferManager.h
@@ -67,7 +67,10 @@ public:
 
 protected:
   using value_type = typename T::value_type;
-  const CVecRef& m_arrays; // reference to the DistrArray objects data is being accessed from
+  // Stored by value, not reference: the convenience constructors below
+  // delegate using temporaries (cwrap(arrays), CVecRef{std::cref(array)})
+  // that would dangle once the delegating call returns.
+  const CVecRef m_arrays; // the DistrArray objects data is being accessed from
   const size_t m_buffer_size = 8192;
   const int m_number_of_buffers = 2;
   size_t m_current_buffer_size;

--- a/src/molpro/linalg/array/util/DistrFlags.cpp
+++ b/src/molpro/linalg/array/util/DistrFlags.cpp
@@ -20,7 +20,7 @@ DistrFlags::DistrFlags(MPI_Comm comm, int value) : m_comm{comm} {
 
 DistrFlags::~DistrFlags() {
   if (!empty()) {
-    if (!m_counter || (m_counter && *m_counter != 0))
+    if (!m_counter || *m_counter != 0)
       MPI_Abort(m_comm, 1);
     MPI_Win_free(&m_win);
   }

--- a/src/molpro/linalg/array/util/Distribution.h
+++ b/src/molpro/linalg/array/util/Distribution.h
@@ -53,7 +53,7 @@ public:
    * @param ind array index
    */
   int cover(index_type ind) const {
-    if (ind < border().first || ind > border().second)
+    if (m_chunk_borders.empty() || ind < border().first || ind >= border().second)
       return size();
     auto iter = std::upper_bound(begin(m_chunk_borders), end(m_chunk_borders), ind);
     int chunk = iter == begin(m_chunk_borders) ? size() : distance(begin(m_chunk_borders), prev(iter));

--- a/src/molpro/linalg/array/util/Distribution.h
+++ b/src/molpro/linalg/array/util/Distribution.h
@@ -62,11 +62,15 @@ public:
 
   //! Returns [fist, end) indices for section of array assigned to chunk
   std::pair<index_type, index_type> range(int chunk) const {
+    assert(chunk >= 0 && static_cast<size_t>(chunk) < size() && "chunk index out of range");
     return {m_chunk_borders[chunk], m_chunk_borders[chunk + 1]};
   };
 
   //! @returns [start, end) indices of the distribution
-  std::pair<index_type, index_type> border() const { return {m_chunk_borders.front(), m_chunk_borders.back()}; }
+  std::pair<index_type, index_type> border() const {
+    assert(!m_chunk_borders.empty() && "border() called on default-constructed Distribution");
+    return {m_chunk_borders.front(), m_chunk_borders.back()};
+  }
 
   //! Number of chunks in the distribution
   size_t size() const { return m_chunk_borders.size() ? m_chunk_borders.size() - 1 : 0; };

--- a/src/molpro/linalg/array/util/gather_all.h
+++ b/src/molpro/linalg/array/util/gather_all.h
@@ -2,6 +2,7 @@
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ARRAY_UTIL_GATHER_ALL_H
 #include <molpro/linalg/array/util/Distribution.h>
 #include <mpi.h>
+#include <vector>
 
 namespace molpro::linalg::array::util {
 
@@ -12,16 +13,16 @@ namespace molpro::linalg::array::util {
  * @param commun MPI communicator
  * @param first_elem pointer to the beginning of the container, which data to be replicated
  */
-void gather_all(const Distribution<size_t>& distr, MPI_Comm commun, double* first_elem) {
+inline void gather_all(const Distribution<size_t>& distr, MPI_Comm commun, double* first_elem) {
   int nproc, mpi_rank;
   MPI_Comm_size(commun, &nproc);
   MPI_Comm_rank(commun, &mpi_rank);
-  int chunks[nproc], displs[nproc];
+  std::vector<int> chunks(nproc), displs(nproc);
   for (int i = 0; i < nproc; i++) {
     displs[i] = distr.range(i).first;
     chunks[i] = distr.range(i).second - distr.range(i).first;
   }
-  MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, first_elem, chunks, displs, MPI_DOUBLE, commun);
+  MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, first_elem, chunks.data(), displs.data(), MPI_DOUBLE, commun);
 }
 
 } // namespace molpro::linalg::array::util

--- a/src/molpro/linalg/array/util/select_max_dot.h
+++ b/src/molpro/linalg/array/util/select_max_dot.h
@@ -64,16 +64,12 @@ auto select_max_dot_iter_sparse(size_t n, const X& x, const Y& y) {
   using std::greater;
   using select_pair = std::pair<value_type_abs, size_t>; // value and index
   auto selection = std::priority_queue<select_pair, std::vector<select_pair>, greater<select_pair>>();
-  auto iy = begin(y);
-  for (size_t i = 0; i < n; ++i, ++iy) {
-    if (iy->first < x.size())
-      selection.emplace(abs(x[iy->first] * iy->second), iy->first);
-  }
-  for (auto jy = iy; jy != end(y); ++jy) {
-    if (jy->first < x.size()) {
-      selection.emplace(abs(x[jy->first] * jy->second), jy->first);
+  for (auto iy = begin(y); iy != end(y); ++iy) {
+    if (iy->first >= x.size())
+      continue;
+    selection.emplace(abs(x[iy->first] * iy->second), iy->first);
+    if (selection.size() > n)
       selection.pop();
-    }
   }
   auto selection_map = std::map<size_t, value_type_abs>();
   auto m = selection.size();
@@ -104,21 +100,13 @@ auto select_max_dot_sparse(size_t n, const X& x, const Y& y) {
   using std::greater;
   using select_pair = std::pair<value_type_abs, size_t>; // value and index
   auto selection = std::priority_queue<select_pair, std::vector<select_pair>, greater<select_pair>>();
-  auto ix = begin(x);
-  auto iy = begin(y);
-  while (selection.size() < n && ix != end(x)) {
-    iy = y.find(ix->first);
-    if (iy != y.end())
-      selection.emplace(abs(ix->second * iy->second), ix->first);
-    ++ix;
-  }
-  while (ix != end(x)) {
-    iy = y.find(ix->first);
-    if (iy != y.end()) {
-      selection.emplace(abs(ix->second * iy->second), ix->first);
+  for (auto ix = begin(x); ix != end(x); ++ix) {
+    auto iy = y.find(ix->first);
+    if (iy == y.end())
+      continue;
+    selection.emplace(abs(ix->second * iy->second), ix->first);
+    if (selection.size() > n)
       selection.pop();
-    }
-    ++ix;
   }
   auto selection_map = std::map<size_t, value_type_abs>();
   auto m = selection.size();

--- a/src/molpro/linalg/array/util/temp_file.cpp
+++ b/src/molpro/linalg/array/util/temp_file.cpp
@@ -27,11 +27,13 @@ fs::path temp_file_name(const fs::path& base_name, const std::string& suffix, MP
 }
 #endif
 
+namespace {
 int s_temp_file_name_count = 0;
 std::mutex s_mutex;
+} // namespace
 fs::path temp_file_name(const fs::path& base_name, const std::string& suffix) {
   auto lock = std::lock_guard(s_mutex);
-  const std::string chars = "01234566789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const std::string chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const int length = 32;
   std::hash<std::thread::id> hasher;
   auto time = std::chrono::high_resolution_clock().now().time_since_epoch().count();

--- a/test/array/parallel_util.cpp
+++ b/test/array/parallel_util.cpp
@@ -11,20 +11,12 @@ std::tuple<std::vector<molpro::linalg::array::DistrArraySpan>, std::vector<molpr
   //std::vector<std::vector<double>> vx(n, std::vector<double>(dim)), vy(n, std::vector<double>(dim)),
   //    vz(n, std::vector<double>(dim));
 
+  // NOTE: these buffers are deliberately leaked. The returned DistrArraySpan
+  // objects hold non-owning views into vx_mem/vy_mem; we cannot delete[] them
+  // here without dangling those views. Test utility only.
   double* vx_mem = new double[n*dim];
   double* vy_mem = new double[n*dim];
   double* vz_mem = new double[n*dim];
-
-//  std::vector<Span<double>> vx, vy, vz;
-std::vector<molpro::linalg::array::span::Span<double>> vz;
-//  vx.reserve(n);
-//  vy.reserve(n);
-  vz.reserve(n);
-  for (size_t i=0; i<n; i++){
-//    vx.emplace_back( Span(vx_mem+(i*n), dim) );
-//    vy.emplace_back( Span(vy_mem+(i*n), dim) );
-    vz.emplace_back( molpro::linalg::array::span::Span(vz_mem+(i*n), dim) );
-  }
 
   std::vector<molpro::linalg::array::DistrArraySpan> cx;
   std::vector<molpro::linalg::array::DistrArraySpan> cy;


### PR DESCRIPTION
Eighth in the series.

## Commits

### 1. `DistrArray family: empty-input guards and scatter indexing fix`
- DistrArray sparse overloads (`dot`, `axpy`, `select_max_dot`) dereffed `y.rbegin()` without first checking `y.empty()` — UB on an empty std::map. Return early.
- `DistrArrayFile::scatter` indexed into `data` using `i - *minmax.first`, which assumes indices are sorted (and contiguous from the min). For an unsorted indices vector every element after the min read the wrong slot of data, and on an empty vector `minmax_element` was dereffed unchecked. Iterate by position so `data[k]` corresponds to `indices[k]`, and bail out early when empty.
- `DistrArrayFile.h`: drop the namespace-scope `using molpro::mpi::comm_global;` from this public header. Qualify default arguments at the declaration sites.

### 2. `array/Span.h: fix C++20 alias and const_reference type`
- The C++20 branch aliased `Span = std::span` — a class template — to a non-templated type. Make it a templated using alias so `Span<T>` resolves to `std::span<T>`.
- `const_reference` was typedef'd to `T&` instead of `const T&`. Two consumer sites (`DistrArrayDisk::LocalBufferDisk` ctor, `DistrArraySpan(const DistrArray&)`) were silently relying on the wrong typedef to assign through const-reffed Spans. They now use an explicit `const_cast` with a comment explaining the semantic (those views are mutable by design despite the const-ref API).

### 3. `array/util: lifetimes, bounds, sparse selection, and axpy doc`
- `BufferManager` stored the constructor's `CVecRef` by reference; the two convenience constructors pass a temporary, so the reference was dangling immediately. Store by value.
- `Distribution::range` / `Distribution::border` had no bounds check and would deref `end()` on a default-constructed instance. Add asserts.
- `select_max_dot_iter_sparse` / `select_max_dot_sparse` always called `selection.pop()` after `emplace` in the tail loop, even when the queue had not yet reached size n. Valid candidates were dropped whenever earlier entries were skipped. Use the standard "emplace then pop only if size > n" pattern.
- `ArrayHandler::counter_to_string`: axpy label was `R = a*L + R` but for handler<AL, AR> the destination is L and the source is R. Swap.

### 4. `DistrArray: span lifetime, scatter indexing, error logging, internal linkage`
- `DistrArraySpan::scatter` had the same `data[i - *minmax.first]` indexing bug we fixed for `DistrArrayFile::scatter`; iterate by position, guard empty, also use `>= hi_loc` since hi_loc is past-the-end; scatter error message no longer mislabels itself as "gather".
- `DistrArraySpan(const DistrArray& source)` passed `source.size()` (global) instead of the local buffer's size, and addressed the buffer through a temporary `unique_ptr<LocalBuffer>` that died at end-of-full-expression. Hold the LocalBuffer for the duration of `allocate_buffer()` and use its local size. A comment flags that this constructor is unsafe for disk-backed sources.
- `DistrArrayMPI3::error` swallowed the diagnostic before calling `MPI_Abort`; print to cerr first.
- `Distribution::cover` treated `ind == border().second` (past-the-end) as in-range; reject it (`>=` instead of `>`), and handle the default-constructed (empty) case.
- `test/array/parallel_util.cpp` had a dead local Span vector with a wrong i*n offset; drop the dead block and document the deliberate buffer leak.
- `temp_file.cpp`: drop the stray duplicate '6' from the random charset, and move file-scope statics into an anonymous namespace.

### 5. `DistrArray: size_t underflow, stray semicolon, VLA → vector, DistrFlags dtor`
- `~DistrArrayFile` (Windows branch) had a stray `;` after the `if`, so `fs::remove` ran unconditionally. Drop the semicolon.
- `DistrArrayFile::get` could underflow `size_t` when the file is shorter than the requested offset; bail out when `current <= offset` (zeroing the buffer) and only compute the difference once known positive.
- `DistrArrayFile::gather`: empty-guard + `>= hi_loc` fix, same as `DistrArraySpan::gather`.
- `s_open_error_mutex` in `DistrArrayFile.cpp` had external linkage. Anonymous namespace.
- `gather_all.h` relied on VLAs (a GCC extension in C++, unsupported by MSVC). Switch to `std::vector<int>`. Also `inline` the function since it was defined non-inline in a header (ODR-clashes with a second TU).
- `DistrFlags::~DistrFlags` had `!m_counter || (m_counter && *m_counter != 0)`; the inner `m_counter &&` is dead under short-circuit. Simplify.

### 6. `array/util Task: guard against throwing destructor on moved-from instance`
`Task::~Task()` called `wait()` unconditionally, but `wait()` throws `std::future_error` when the underlying future is invalid (exactly the state of a moved-from Task). A throwing destructor in a non-noexcept context would terminate the program. Guard with `valid()`.

## Test
Library + full test executable build clean locally with `-DMPI=ON`.

Series cousins: #559, #560, #561, #562, #565 (merged); #563, #564, #566 (open).