### PR TITLE
HDF5 / PHDF5 / DistrArrayGA: leaks, ownership, bounds

### DIFF
--- a/src/molpro/linalg/array/DistrArrayGA.cpp
+++ b/src/molpro/linalg/array/DistrArrayGA.cpp
@@ -128,7 +128,7 @@ void DistrArrayGA::get(index_type lo, index_type hi, value_type *buf) const {
     return;
   check_ga_ind_overlow(lo);
   check_ga_ind_overlow(hi);
-  int ld, ilo = lo, ihi = int(hi) - 1;
+  int ld = 1, ilo = lo, ihi = int(hi) - 1;
   NGA_Get(m_ga_handle, &ilo, &ihi, buf, &ld);
 }
 
@@ -145,7 +145,7 @@ void DistrArrayGA::put(index_type lo, index_type hi, const value_type *data) {
     return;
   check_ga_ind_overlow(lo);
   check_ga_ind_overlow(hi);
-  int ld, ilo = lo, ihi = int(hi) - 1;
+  int ld = 1, ilo = lo, ihi = int(hi) - 1;
   NGA_Put(m_ga_handle, &ilo, &ihi, const_cast<value_type *>(data), &ld);
 }
 
@@ -155,11 +155,10 @@ std::vector<DistrArrayGA::value_type> DistrArrayGA::gather(const std::vector<ind
   int n = indices.size();
   auto data = std::vector<double>(n);
   auto iind = std::vector<int>(indices.begin(), indices.end());
-  int **subsarray = new int *[n];
+  auto subsarray = std::vector<int *>(n);
   for (int i = 0; i < n; ++i)
     subsarray[i] = &(iind.at(i));
-  NGA_Gather(m_ga_handle, data.data(), subsarray, n);
-  delete[] subsarray;
+  NGA_Gather(m_ga_handle, data.data(), subsarray.data(), n);
   return data;
 }
 
@@ -168,11 +167,10 @@ void DistrArrayGA::scatter(const std::vector<index_type> &indices, const std::ve
     check_ga_ind_overlow(el);
   int n = indices.size();
   auto iind = std::vector<int>(indices.begin(), indices.end());
-  int **subsarray = new int *[n];
+  auto subsarray = std::vector<int *>(n);
   for (int i = 0; i < n; ++i)
     subsarray[i] = &(iind.at(i));
-  NGA_Scatter(m_ga_handle, const_cast<double *>(data.data()), subsarray, n);
-  delete[] subsarray;
+  NGA_Scatter(m_ga_handle, const_cast<double *>(data.data()), subsarray.data(), n);
 }
 
 void DistrArrayGA::scatter_acc(std::vector<index_type> &indices, const std::vector<value_type> &data) {
@@ -180,29 +178,30 @@ void DistrArrayGA::scatter_acc(std::vector<index_type> &indices, const std::vect
     check_ga_ind_overlow(el);
   int n = indices.size();
   auto iind = std::vector<int>(indices.begin(), indices.end());
-  int **subsarray = new int *[n];
+  auto subsarray = std::vector<int *>(n);
   for (int i = 0; i < n; ++i) {
     subsarray[i] = &(iind.at(i));
   }
   value_type alpha = 1;
-  NGA_Scatter_acc(m_ga_handle, const_cast<double *>(data.data()), subsarray, n, &alpha);
-  delete[] subsarray;
+  NGA_Scatter_acc(m_ga_handle, const_cast<double *>(data.data()), subsarray.data(), n, &alpha);
 }
 
 std::vector<DistrArrayGA::value_type> DistrArrayGA::vec() const {
   check_ga_ind_overlow(m_dimension);
   std::vector<double> vec(m_dimension);
   double *buffer = vec.data();
-  int lo = 0, hi = int(m_dimension) - 1, ld;
+  int lo = 0, hi = int(m_dimension) - 1, ld = 1;
   NGA_Get(m_ga_handle, &lo, &hi, buffer, &ld);
   return vec;
 }
 
 void DistrArrayGA::acc(index_type lo, index_type hi, const value_type *data) {
+  if (lo >= hi)
+    return;
   check_ga_ind_overlow(lo);
   check_ga_ind_overlow(hi);
   double scaling_constant = 1;
-  int ld, ilo = lo, ihi = hi;
+  int ld = 1, ilo = lo, ihi = int(hi) - 1;
   NGA_Acc(m_ga_handle, &ilo, &ihi, const_cast<double *>(data), &ld, &scaling_constant);
 }
 

--- a/src/molpro/linalg/array/DistrArrayHDF5.cpp
+++ b/src/molpro/linalg/array/DistrArrayHDF5.cpp
@@ -145,6 +145,9 @@ void DistrArrayHDF5::get(index_type lo, index_type hi, value_type *buf) const {
   auto plist_id = H5Pcreate(H5P_DATASET_XFER);
   H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
   auto ierr = H5Dread(m_dataset, H5T_NATIVE_DOUBLE, memspace, fspace, plist_id, buf);
+  H5Sclose(memspace);
+  H5Sclose(fspace);
+  H5Pclose(plist_id);
   if (ierr < 0)
     error("read failed");
 }
@@ -159,6 +162,8 @@ std::vector<DistrArrayHDF5::value_type> DistrArrayHDF5::get(DistrArray::index_ty
 }
 
 void DistrArrayHDF5::put(DistrArray::index_type lo, DistrArray::index_type hi, const DistrArray::value_type *data) {
+  if (lo >= hi)
+    return;
   if (!dataset_is_open())
     error("call open_access() before RMA operations");
   hsize_t count[1] = {hi - lo};
@@ -169,11 +174,16 @@ void DistrArrayHDF5::put(DistrArray::index_type lo, DistrArray::index_type hi, c
   auto plist_id = H5Pcreate(H5P_DATASET_XFER);
   H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
   auto ierr = H5Dwrite(m_dataset, H5T_NATIVE_DOUBLE, memspace, fspace, plist_id, data);
+  H5Sclose(memspace);
+  H5Sclose(fspace);
+  H5Pclose(plist_id);
   if (ierr < 0)
-    error("read failed");
+    error("write failed");
 }
 
 void DistrArrayHDF5::acc(index_type lo, index_type hi, const value_type *data) {
+  if (lo >= hi)
+    return;
   auto disk_copy = get(lo, hi);
   std::transform(begin(disk_copy), end(disk_copy), data, begin(disk_copy), [](auto &l, auto &r) { return l + r; });
   put(lo, hi, &disk_copy[0]);
@@ -184,6 +194,8 @@ std::vector<DistrArrayHDF5::value_type> DistrArrayHDF5::gather(const std::vector
     error("call open_access() before RMA operations");
   auto sz = indices.size();
   auto data = std::vector<value_type>(sz);
+  if (sz == 0)
+    return data;
   hsize_t count[] = {sz};
   auto memspace = H5Screate_simple(1, count, nullptr);
   auto fspace = H5Dget_space(m_dataset);
@@ -193,6 +205,9 @@ std::vector<DistrArrayHDF5::value_type> DistrArrayHDF5::gather(const std::vector
   auto plist_id = H5Pcreate(H5P_DATASET_XFER);
   H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
   auto ierr = H5Dread(m_dataset, H5T_NATIVE_DOUBLE, memspace, fspace, plist_id, &data[0]);
+  H5Sclose(memspace);
+  H5Sclose(fspace);
+  H5Pclose(plist_id);
   if (ierr < 0)
     error("read failed");
   return data;
@@ -202,6 +217,8 @@ void DistrArrayHDF5::scatter(const std::vector<index_type> &indices, const std::
   if (!dataset_is_open())
     error("call open_access() before RMA operations");
   auto sz = indices.size();
+  if (sz == 0)
+    return;
   hsize_t count[] = {sz};
   auto memspace = H5Screate_simple(1, count, nullptr);
   auto fspace = H5Dget_space(m_dataset);
@@ -211,8 +228,11 @@ void DistrArrayHDF5::scatter(const std::vector<index_type> &indices, const std::
   auto plist_id = H5Pcreate(H5P_DATASET_XFER);
   H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
   auto ierr = H5Dwrite(m_dataset, H5T_NATIVE_DOUBLE, memspace, fspace, plist_id, &data[0]);
+  H5Sclose(memspace);
+  H5Sclose(fspace);
+  H5Pclose(plist_id);
   if (ierr < 0)
-    error("read failed");
+    error("write failed");
 }
 
 void DistrArrayHDF5::scatter_acc(std::vector<index_type> &indices, const std::vector<value_type> &data) {

--- a/src/molpro/linalg/array/HDF5Handle.cpp
+++ b/src/molpro/linalg/array/HDF5Handle.cpp
@@ -250,18 +250,22 @@ bool hdf5_file_is_open(hid_t file_id) { return H5Fget_obj_count(file_id, H5F_OBJ
 
 std::string hdf5_get_object_name(hid_t id) {
   auto size = H5Iget_name(id, nullptr, 0);
+  if (size < 0)
+    return {};
   std::string result;
-  result.resize(size + 1);
+  result.resize(static_cast<size_t>(size) + 1);
   H5Iget_name(id, &result[0], size + 1);
-  result.resize(size);
+  result.resize(static_cast<size_t>(size));
   return result;
 }
 std::string hdf5_get_file_name(hid_t id) {
   auto size = H5Fget_name(id, nullptr, 0);
+  if (size < 0)
+    return {};
   std::string result;
-  result.resize(size + 1);
+  result.resize(static_cast<size_t>(size) + 1);
   H5Fget_name(id, &result[0], size + 1);
-  result.resize(size); // get rid of the null terminator
+  result.resize(static_cast<size_t>(size)); // get rid of the null terminator
   return result;
 }
 //  "/group1/group2/dataset/does_not_exist"

--- a/src/molpro/linalg/array/PHDF5Handle.cpp
+++ b/src/molpro/linalg/array/PHDF5Handle.cpp
@@ -18,6 +18,7 @@ PHDF5Handle::PHDF5Handle(const PHDF5Handle& source, MPI_Comm comm) : PHDF5Handle
 PHDF5Handle::PHDF5Handle(const PHDF5Handle& source) : PHDF5Handle{source, source.m_comm} {}
 PHDF5Handle& PHDF5Handle::operator=(const PHDF5Handle& source) {
   static_cast<HDF5Handle&>(*this) = static_cast<const HDF5Handle&>(source);
+  m_comm = source.m_comm;
   return *this;
 }
 PHDF5Handle::PHDF5Handle(PHDF5Handle&& source, MPI_Comm comm) noexcept : PHDF5Handle{comm} {

--- a/src/molpro/linalg/array/PHDF5Handle.cpp
+++ b/src/molpro/linalg/array/PHDF5Handle.cpp
@@ -23,7 +23,7 @@ PHDF5Handle& PHDF5Handle::operator=(const PHDF5Handle& source) {
 PHDF5Handle::PHDF5Handle(PHDF5Handle&& source, MPI_Comm comm) noexcept : PHDF5Handle{comm} {
   *this = std::forward<PHDF5Handle>(source);
 }
-PHDF5Handle::PHDF5Handle(PHDF5Handle&& source) noexcept : PHDF5Handle{source, source.m_comm} {}
+PHDF5Handle::PHDF5Handle(PHDF5Handle&& source) noexcept : PHDF5Handle{std::move(source), source.m_comm} {}
 PHDF5Handle& PHDF5Handle::operator=(PHDF5Handle&& source) noexcept {
   if (file_is_open())
     close_file();


### PR DESCRIPTION
Ninth in the series.

## Commits

### 1. `PHDF5Handle: pick the move-variant constructor in the move ctor delegation`
The move ctor delegated to `PHDF5Handle{source, source.m_comm}`. Inside the body the named rvalue reference `source` is an lvalue, so overload resolution picked the **copy**-variant ctor and the move was secretly a copy. Cast with `std::move`.

### 2. `DistrArrayGA / DistrArrayHDF5 / HDF5Handle: leaks, ownership, and bounds`
**DistrArrayGA**
- `acc()` converted `int ihi = hi` (treating hi as inclusive) the wrong way for our past-the-end API and wrote one element past the intended range. Use `int(hi) - 1` to match get/put. Also add the same `lo >= hi` early-return.
- `int ld;` was uninitialised when passed to `NGA_Get/Put/Acc`; GA reads it. Initialise to 1.
- `gather` / `scatter` / `scatter_acc` allocated `int **subsarray = new int*[n]` with a manual `delete[]`; any throw between new and delete leaked. Switch to `std::vector<int*>`.

**DistrArrayHDF5**
- `get`, `put`, `gather`, `scatter` created H5S/H5P ids but never released them, leaking three HDF5 ids per RMA call. Close them before returning.
- `put()` and `acc()` were missing the `if (lo >= hi) return;` guard that `get()` has, so `H5Screate_simple` was being called with count 0.
- Error messages in `put()` and `scatter()` read "read failed"; these are writes — say "write failed".
- `gather()` / `scatter()` were missing an early return for empty indices.

**HDF5Handle helpers**
- `hdf5_get_object_name` / `hdf5_get_file_name` didn't check the negative return from `H5Iget_name` / `H5Fget_name`. `result.resize(size + 1)` is well-defined for `size==-1` (silently becomes `resize(0)`), but the subsequent `result.resize(size)` calls `resize(SIZE_MAX)` and throws `bad_alloc`. Return an empty string on error.

### 3. `PHDF5Handle: copy-assign m_comm alongside the HDF5Handle slice`
`operator=(const&)` sliced to `HDF5Handle` and silently preserved the target's `m_comm`, while `operator=(&&)` copied `m_comm` from the source. The asymmetry is surprising and inconsistent with the copy ctor (which delegates with `source.m_comm`). Copy assign `m_comm` too.

## Test
The library builds clean locally with the non-HDF5/non-GA flags (the changed sources are compiled only under HDF5=ON / GA=ON). CI's HDF5-enabled jobs will exercise the HDF5 paths.

Series cousins: #559, #560, #561, #562, #565 (merged); #563, #564, #566, #567 (open).