### PR TITLE
IterativeSolverCMPI: empty-stack guards, dynamic_cast null-checks; example fixes

### DIFF
--- a/examples/LinearEigensystemMultirootExample.cpp
+++ b/examples/LinearEigensystemMultirootExample.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[]) {
       std::cout << "failed" << std::endl;
     else
       std::cout << "converged in " << solver->statistics().iterations << " iterations" << std::endl;
-    std::vector<int> roots;
+    std::vector<int> roots(solver->n_roots());
     std::iota(roots.begin(), roots.end(), 0);
     solver->solution(roots, c, g);
     for (const auto& ev : solver->eigenvalues())

--- a/examples/LinearEquationsExample.cpp
+++ b/examples/LinearEquationsExample.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
     if (!success)
       std::cout << "failed" << std::endl;
     else
-      std::cout << "converged in " << solver->statistics().iterations << " iterations" << std::endl;
+      std::cout << "converged in " << solver2->statistics().iterations << " iterations" << std::endl;
     std::cout << solver2->statistics() << std::endl;
     std::cout << "solution";
     for (const auto& e : c)

--- a/src/molpro/linalg/IterativeSolverCMPI.cpp
+++ b/src/molpro/linalg/IterativeSolverCMPI.cpp
@@ -482,7 +482,15 @@ extern "C" size_t IterativeSolverAddP(size_t buffer_size, size_t nP, const size_
   return working_set_size;
 }
 
+namespace {
+void require_instance() {
+  if (instances.empty())
+    throw std::runtime_error("IterativeSolver not initialised properly");
+}
+} // namespace
+
 extern "C" void IterativeSolverErrors(double* errors) {
+  require_instance();
   auto& instance = instances.top();
   size_t k = 0;
   for (const auto& e : instance.solver.get()->errors())
@@ -491,6 +499,7 @@ extern "C" void IterativeSolverErrors(double* errors) {
 }
 
 extern "C" void IterativeSolverEigenvalues(double* eigenvalues) {
+  require_instance();
   auto& instance = instances.top();
   size_t k = 0;
   LinearEigensystem<Rvector, Qvector, Pvector>* solver_cast =
@@ -502,6 +511,7 @@ extern "C" void IterativeSolverEigenvalues(double* eigenvalues) {
 }
 
 extern "C" void IterativeSolverWorkingSetEigenvalues(double* eigenvalues) {
+  require_instance();
   auto& instance = instances.top();
   size_t k = 0;
   LinearEigensystemDavidson<Rvector, Qvector, Pvector>* solver_cast =
@@ -514,6 +524,7 @@ extern "C" void IterativeSolverWorkingSetEigenvalues(double* eigenvalues) {
 
 extern "C" size_t IterativeSolverSuggestP(const double* solution, const double* residual, size_t maximumNumber,
                                           double threshold, size_t* indices) {
+  require_instance();
   auto& instance = instances.top();
   if (instance.prof != nullptr)
     instance.prof->start("SuggestP");
@@ -528,25 +539,45 @@ extern "C" size_t IterativeSolverSuggestP(const double* solution, const double* 
   return result.size();
 }
 
-extern "C" void IterativeSolverPrintStatistics() { molpro::cout << instances.top().solver->statistics() << std::endl; }
+extern "C" void IterativeSolverPrintStatistics() {
+  require_instance();
+  molpro::cout << instances.top().solver->statistics() << std::endl;
+}
 
-extern "C" int IterativeSolverConverged() { return instances.top().solver->working_set().empty() ? 1 : 0; }
+extern "C" int IterativeSolverConverged() {
+  require_instance();
+  return instances.top().solver->working_set().empty() ? 1 : 0;
+}
 
-int IterativeSolverNonLinear() { return instances.top().solver->nonlinear() ? 1 : 0; }
-int IterativeSolverHasValues() { return instances.top().has_values ? 1 : 0; }
-int IterativeSolverHasEigenvalues() { return instances.top().has_eigenvalues ? 1 : 0; }
+int IterativeSolverNonLinear() {
+  require_instance();
+  return instances.top().solver->nonlinear() ? 1 : 0;
+}
+int IterativeSolverHasValues() {
+  require_instance();
+  return instances.top().has_values ? 1 : 0;
+}
+int IterativeSolverHasEigenvalues() {
+  require_instance();
+  return instances.top().has_eigenvalues ? 1 : 0;
+}
 
 void IterativeSolverSetDiagonals(const double* diagonals) {
+  require_instance();
   instances.top().diagonals.reset(new Qvector(CreateDistrArray(1, diagonals).front()));
 }
 void IterativeSolverDiagonals(double* diagonals) {
+  require_instance();
   CreateDistrArray(1, diagonals).front().copy(*instances.top().diagonals);
 }
-double IterativeSolverValue() { return instances.top().solver->value(); }
+double IterativeSolverValue() {
+  require_instance();
+  return instances.top().solver->value();
+}
 int IterativeSolverVerbosity() {
+  require_instance();
   auto verbosity = instances.top().solver->logger().verbosity();
   auto min_severity = instances.top().solver->logger().min_severity();
-
   switch (verbosity) {
     using namespace molpro::linalg::itsolv;
     case log::Verbosity::None:
@@ -561,8 +592,14 @@ int IterativeSolverVerbosity() {
 
   return -1;
 }
-int IterativeSolverMaxIter() { return instances.top().solver->get_max_iter(); }
-void IterativeSolverSetMaxIter(int max_iter) { instances.top().solver->set_max_iter(max_iter); }
+int IterativeSolverMaxIter() {
+  require_instance();
+  return instances.top().solver->get_max_iter();
+}
+void IterativeSolverSetMaxIter(int max_iter) {
+  require_instance();
+  instances.top().solver->set_max_iter(max_iter);
+}
 /*!
  * @brief C binding of mpi::comm_global(), suitable for calling from Fortran
  */

--- a/src/molpro/linalg/IterativeSolverCMPI.cpp
+++ b/src/molpro/linalg/IterativeSolverCMPI.cpp
@@ -312,8 +312,11 @@ extern "C" void IterativeSolverAddEquation(double* rhs) {
   if (instance.prof != nullptr)
     instance.prof->start("AddEquation");
   auto ccc = CreateDistrArray(1, rhs);
-  dynamic_cast<molpro::linalg::itsolv::LinearEquationsDavidson<Rvector, Qvector, Pvector>*>(instance.solver.get())
-      ->add_equations(ccc[0]);
+  auto* solver =
+      dynamic_cast<molpro::linalg::itsolv::LinearEquationsDavidson<Rvector, Qvector, Pvector>*>(instance.solver.get());
+  if (!solver)
+    throw std::runtime_error("IterativeSolverAddEquation: current solver is not LinearEquationsDavidson");
+  solver->add_equations(ccc[0]);
   if (instance.prof != nullptr) {
     instance.prof->stop();
   }
@@ -329,11 +332,10 @@ extern "C" size_t IterativeSolverAddValue(double value, double* parameters, doub
   auto ggg = CreateDistrArray(1, action);
   if (instance.prof != nullptr)
     instance.prof->start("AddValue:Call");
-  size_t working_set_size =
-      dynamic_cast<molpro::linalg::itsolv::Optimize<Rvector, Qvector, Pvector>*>(instance.solver.get())
-              ->add_vector(ccc[0], ggg[0], value) > 0
-          ? 1
-          : 0;
+  auto* solver = dynamic_cast<molpro::linalg::itsolv::Optimize<Rvector, Qvector, Pvector>*>(instance.solver.get());
+  if (!solver)
+    throw std::runtime_error("IterativeSolverAddValue: current solver is not an Optimize solver");
+  size_t working_set_size = solver->add_vector(ccc[0], ggg[0], value) > 0 ? 1 : 0;
   if (instance.prof != nullptr) {
     instance.prof->stop();
     instance.prof->start("AddValue:Sync");

--- a/src/molpro/linalg/IterativeSolverCMPI.cpp
+++ b/src/molpro/linalg/IterativeSolverCMPI.cpp
@@ -217,6 +217,9 @@ extern "C" void IterativeSolverLinearEquationsInitialize(size_t n, size_t nroot,
   auto& instance = instances.top();
   auto rr = CreateDistrArray(nroot, rhs);
   auto solver = dynamic_cast<LinearEquationsDavidson<Rvector, Qvector, Pvector>*>(instance.solver.get());
+  if (!solver)
+    throw std::runtime_error("IterativeSolverLinearEquationsInitialize: solver factory returned an unexpected type for algorithm \"" +
+                             std::string(algorithm ? algorithm : "") + "\"");
   solver->set_augmented_hessian(aughes);
   solver->set_hermiticity(hermitian);
   solver->set_n_roots(nroot);
@@ -253,6 +256,10 @@ extern "C" void IterativeSolverNonLinearEquationsInitialize(size_t n, size_t* ra
   std::tie(*range_begin, *range_end) = DistrArrayDefaultRange();
   molpro::linalg::itsolv::NonLinearEquationsDIIS<Rvector, Qvector, Pvector>* solver =
       dynamic_cast<molpro::linalg::itsolv::NonLinearEquationsDIIS<Rvector, Qvector, Pvector>*>(instance.solver.get());
+  if (!solver)
+    throw std::runtime_error(
+        "IterativeSolverNonLinearEquationsInitialize: solver factory returned an unexpected type for algorithm \"" +
+        std::string(algorithm ? algorithm : "") + "\"");
   solver->logger->set_verbosity(
      verbosity > 3 ? molpro::linalg::itsolv::log::Verbosity::Trace
                    : (verbosity > 2 ? molpro::linalg::itsolv::log::Verbosity::Debug : molpro::linalg::itsolv::log::Verbosity::Info));
@@ -279,6 +286,10 @@ extern "C" void IterativeSolverOptimizeInitialize(size_t n, size_t* range_begin,
   instance.solver->set_verbosity(verbosity);
   molpro::linalg::itsolv::OptimizeBFGS<Rvector, Qvector, Pvector>* solver =
       dynamic_cast<molpro::linalg::itsolv::OptimizeBFGS<Rvector, Qvector, Pvector>*>(instance.solver.get());
+  if (!solver)
+    throw std::runtime_error(
+        "IterativeSolverOptimizeInitialize: BFGS-specific configuration requested but the factory returned a different algorithm for \"" +
+        std::string(algorithm ? algorithm : "") + "\"");
   solver->logger->set_verbosity(
      verbosity > 3 ? molpro::linalg::itsolv::log::Verbosity::Trace
                    : (verbosity > 2 ? molpro::linalg::itsolv::log::Verbosity::Debug : molpro::linalg::itsolv::log::Verbosity::Info));

--- a/src/molpro/linalg/IterativeSolverCMPI.cpp
+++ b/src/molpro/linalg/IterativeSolverCMPI.cpp
@@ -417,7 +417,7 @@ extern "C" size_t IterativeSolverEndIteration(size_t buffer_size, double* soluti
   auto result = instance.solver->end_iteration(cc, gg);
   if (instance.prof != nullptr) {
     instance.prof->stop();
-    instance.prof->start("AddVector:Sync");
+    instance.prof->start("EndIter:Sync");
   }
   if (sync) {
     DistrArraySynchronize(instance.solver->working_set().size(), cc, solution);
@@ -431,6 +431,8 @@ extern "C" size_t IterativeSolverEndIteration(size_t buffer_size, double* soluti
 }
 
 extern "C" int IterativeSolverEndIterationNeeded(){
+  if (instances.empty())
+    throw std::runtime_error("IterativeSolver not initialised properly");
   auto& instance = instances.top();
   return instance.solver->end_iteration_needed() ? 1:0;
 }
@@ -438,6 +440,8 @@ extern "C" int IterativeSolverEndIterationNeeded(){
 extern "C" size_t IterativeSolverAddP(size_t buffer_size, size_t nP, const size_t* offsets, const size_t* indices,
                                       const double* coefficients, const double* pp, double* parameters, double* action,
                                       int sync, apply_on_p_t func) {
+  if (instances.empty())
+    throw std::runtime_error("IterativeSolver not initialised properly");
   auto& instance = instances.top();
   instance.apply_on_p_fort = func;
   if (instance.prof != nullptr)


### PR DESCRIPTION
Tenth (and final) PR in the series replacing #556.

## Commits

### 1. `IterativeSolverCMPI: null-check the *Initialize dynamic_casts`
The three `*Initialize` routines (`LinearEquations`, `NonLinearEquations`, `Optimize`) dereffed the result of `dynamic_cast<ConcreteSolver*>` to configure solver-specific knobs (logger, hermiticity, augmented hessian). If the factory ever returned a different concrete type (e.g. `OptimizeSD` for `algorithm="SD"`) the deref would segfault. Throw an explicit `runtime_error` naming the algorithm string instead.

### 2. `IterativeSolverCMPI: empty-stack guards and profiler section name`
* `IterativeSolverEndIterationNeeded` and `IterativeSolverAddP` dereffed `instances.top()` without first checking the stack was non-empty; throw `runtime_error` like the sibling routines.
* `IterativeSolverEndIteration` was starting a profiler section called `"AddVector:Sync"` — copy-paste from the matching call in `AddVector`. Rename to `"EndIter:Sync"`.

### 3. `IterativeSolverCMPI: add a require_instance() helper for unguarded entries`
Many C-API entries (`Errors`, `Eigenvalues`, `WorkingSetEigenvalues`, `SuggestP`, `PrintStatistics`, `Converged`, `NonLinear`, `HasValues`, `HasEigenvalues`, `SetDiagonals`, `Diagonals`, `Value`, `Verbosity`, `MaxIter`, `SetMaxIter`) read `instances.top()` unguarded — empty stack -> UB. Add one helper that throws `runtime_error` and call it at the top of each. Behaviour is unchanged when the stack is non-empty; previously-UB-on-empty paths now throw a labelled error.

### 4. `CMPI + example: null-check Add* casts, fix solver/solver2 mixup`
* `IterativeSolverAddEquation` / `IterativeSolverAddValue` dereffed unchecked `dynamic_cast` results (left over from the pass-3 / pass-7 sweep of `*Initialize`). Add the same explicit null check + named `runtime_error`.
* `LinearEquationsExample.cpp`'s "new" code path reported `solver->statistics().iterations` in the success branch, but only `solver2` is alive there — the line below it correctly prints `solver2->statistics()`. Use `solver2` in both spots.

### 5. `LinearEigensystemMultirootExample: size roots before iota`
The example left `roots` default-constructed (empty) before calling `std::iota(roots.begin(), roots.end(), 0)` and `solver->solution(roots, c, g)`, so it never actually retrieved any solutions. Size to `solver->n_roots()`.

## Test
Library + Fortran builds clean locally with `-DMPI=ON`.

## Series complete
This is the last PR in the resplit of #556. Cousins (all open or merged):
- Merged: #559 (CMake hygiene), #560 (docs), #561 (dead code), #562 (header hygiene), #565 (audit playbook).
- Open: #563 (Python), #564 (Fortran), #566 (itsolv core), #567 (DistrArray family), #568 (HDF5/GA), this.