### PR TITLE
Implement dynamic Q-space pruning

### DIFF
--- a/src/molpro/linalg/itsolv/CMakeLists.txt
+++ b/src/molpro/linalg/itsolv/CMakeLists.txt
@@ -1,5 +1,6 @@
 LibraryManager_Append(${PROJECT_NAME}
     SOURCES
+        DavidsonOptions.cpp
         LinearEigensystemDavidsonOptions.cpp
         LinearEigensystemRSPTOptions.cpp
         LinearEquationsDavidsonOptions.cpp
@@ -11,6 +12,7 @@ LibraryManager_Append(${PROJECT_NAME}
         NonLinearEquationsDIISOptions.cpp
     PUBLIC_HEADER
         CastOptions.h
+        DavidsonOptions.h
         DSpaceResetter.h
         IterativeSolverTemplate.h
         LinearEigensystemDavidson.h

--- a/src/molpro/linalg/itsolv/CMakeLists.txt
+++ b/src/molpro/linalg/itsolv/CMakeLists.txt
@@ -1,13 +1,40 @@
 LibraryManager_Append(${PROJECT_NAME}
-        SOURCES util.cpp Options.cpp LinearEigensystemDavidsonOptions.cpp LinearEquationsDavidsonOptions.cpp
-        NonLinearEquationsDIISOptions.cpp OptimizeBFGSOptions.cpp OptimizeSDOptions.cpp LinearEigensystemRSPTOptions.cpp
+    SOURCES
+        LinearEigensystemDavidsonOptions.cpp
+        LinearEigensystemRSPTOptions.cpp
+        LinearEquationsDavidsonOptions.cpp
+        OptimizeBFGSOptions.cpp
+        OptimizeSDOptions.cpp
+        Options.cpp
+        util.cpp
         Interpolate.cpp
-        PUBLIC_HEADER IterativeSolver.h IterativeSolverTemplate.h LinearEigensystemDavidson.h LinearEigensystemRSPT.h
-        LinearEquationsDavidson.h NonLinearEquationsDIIS.h OptimizeBFGS.h OptimizeSD.h Options.h
-        Logger.h wrap.h wrap_util.h propose_rspace.h util.h DSpaceResetter.h CastOptions.h
-        LinearEigensystemDavidsonOptions.h LinearEigensystemRSPTOptions.h LinearEquationsDavidsonOptions.h
-        NonLinearEquationsDIISOptions.h OptimizeBFGSOptions.h OptimizeSDOptions.h
-        SolverFactory.h SolverFactory-implementation.h options_map.h
+        NonLinearEquationsDIISOptions.cpp
+    PUBLIC_HEADER
+        CastOptions.h
+        DSpaceResetter.h
+        IterativeSolverTemplate.h
+        LinearEigensystemDavidson.h
+        LinearEigensystemRSPT.h
+        LinearEigensystemRSPTOptions.h
+        LinearEquationsDavidsonOptions.h
+        NonLinearEquationsDIIS.h
+        OptimizeBFGS.h
+        OptimizeBFGSOptions.h
+        OptimizeSD.h
+        OptimizeSDOptions.h
+        Options.h
+        SolverFactory-implementation.h
+        options_map.h
+        propose_rspace.h
+        util.h
+        wrap.h
+        wrap_util.h
+        IterativeSolver.h
         Interpolate.h
-        )
+        LinearEigensystemDavidsonOptions.h
+        LinearEquationsDavidson.h
+        Logger.h
+        NonLinearEquationsDIISOptions.h
+        SolverFactory.h
+)
 add_subdirectory(subspace)

--- a/src/molpro/linalg/itsolv/DSpaceResetter.h
+++ b/src/molpro/linalg/itsolv/DSpaceResetter.h
@@ -9,13 +9,16 @@
 #include <molpro/linalg/itsolv/subspace/util.h>
 #include <molpro/linalg/itsolv/util.h>
 
+#include <cstddef>
+#include <limits>
+
 namespace molpro::linalg::itsolv::detail {
 //! Removes Q parameters that have smallest contribution to any solution until Q space size is within limit
 template <class R, class Q, class P, typename value_type>
 void resize_qspace(subspace::IXSpace<R, Q, P>& xspace, const subspace::Matrix<value_type>& solutions,
-                   int m_max_Qsize_after_reset, Logger& logger) {
+                   std::size_t max_size, Logger& logger) {
   logger.trace("resize_qspace()");
-  auto q_delete = limit_qspace_size(xspace.dimensions(), m_max_Qsize_after_reset, solutions, logger);
+  auto q_delete = limit_qspace_size(xspace.dimensions(), max_size, solutions, logger);
   logger.debug("delete Q parameter indices = ", q_delete);
   std::sort(begin(q_delete), end(q_delete), std::greater<int>());
   for (auto iq : q_delete)
@@ -69,13 +72,14 @@ auto max_overlap_with_R(const CVecRef<R>& rparams, const CVecRef<Q>& qparams, ar
 template <class Q>
 class DSpaceResetter {
 protected:
-  int m_nreset = std::numeric_limits<int>::max();                //!< reset D space every n iterations
-  int m_max_Qsize_after_reset = std::numeric_limits<int>::max(); //!< maximum size of Q space after reset
-  std::list<Q> solution_params; //!< all current solutions that will be moved to the Q space
+  std::size_t m_nreset = std::numeric_limits<std::size_t>::max(); //!< reset D space every n iterations
+  std::size_t m_max_Qsize_after_reset =
+      std::numeric_limits<std::size_t>::max(); //!< maximum size of Q space after reset
+  std::list<Q> solution_params;                //!< all current solutions that will be moved to the Q space
 
 public:
   DSpaceResetter() = default;
-  DSpaceResetter(int nreset, int max_Qsize) : m_nreset{nreset}, m_max_Qsize_after_reset{max_Qsize} {}
+  DSpaceResetter(std::size_t nreset, std::size_t max_Qsize) : m_nreset{nreset}, m_max_Qsize_after_reset{max_Qsize} {}
 
   //! Whether reset operation should be run
   bool do_reset(size_t iter, const subspace::Dimensions& dims) {
@@ -135,8 +139,8 @@ public:
     auto q_delete = max_overlap_with_R(wparams, xspace.cparamsq(), handlers.rq(), logger);
     for (auto i : q_delete)
       xspace.eraseq(i);
-    if (xspace.dimensions().nQ + nR > size_t(m_max_Qsize_after_reset))
-      resize_qspace(xspace, solutions, size_t(m_max_Qsize_after_reset) > nR ? m_max_Qsize_after_reset - nR : 0, logger);
+    if (xspace.dimensions().nQ + nR > m_max_Qsize_after_reset)
+      resize_qspace(xspace, solutions, m_max_Qsize_after_reset > nR ? m_max_Qsize_after_reset - nR : 0, logger);
     auto new_working_set = std::vector<int>(nR);
     std::iota(begin(new_working_set), end(new_working_set), 0);
     return new_working_set;

--- a/src/molpro/linalg/itsolv/DSpaceResetter.h
+++ b/src/molpro/linalg/itsolv/DSpaceResetter.h
@@ -86,15 +86,9 @@ public:
     return ((iter + 1) % m_nreset == 0 && dims.nD > 0) || !solution_params.empty();
   }
 
-  void set_nreset(size_t i) {
-    assert(i >= 0);
-    m_nreset = i;
-  }
+  void set_nreset(size_t i) { m_nreset = i; }
   auto get_nreset() const { return m_nreset; }
-  void set_max_Qsize(size_t i) {
-    assert(i >= 0);
-    m_max_Qsize_after_reset = i;
-  }
+  void set_max_Qsize(size_t i) { m_max_Qsize_after_reset = i; }
   auto get_max_Qsize() const { return m_max_Qsize_after_reset; }
 
   //! Run the reset operation

--- a/src/molpro/linalg/itsolv/DSpaceResetter.h
+++ b/src/molpro/linalg/itsolv/DSpaceResetter.h
@@ -44,7 +44,8 @@ auto max_overlap_with_R(const CVecRef<R>& rparams, const CVecRef<Q>& qparams, ar
       ov.push_back(std::abs(overlap(i, j)));
     auto it_max = std::max_element(ov.begin(), ov.end());
     auto i_max = std::distance(ov.begin(), it_max);
-    logger.debug("removed q index = " + std::to_string(q_indices[i_max]) + ", with overlap = " + std::to_string(*it_max));
+    logger.debug("removed q index = " + std::to_string(q_indices[i_max]) +
+                 ", with overlap = " + std::to_string(*it_max));
     q_max_overlap.push_back(q_indices[i_max]);
     q_indices.erase(q_indices.begin() + i_max);
   }
@@ -99,7 +100,7 @@ public:
                        const value_type_abs svd_thresh, ArrayHandlers<R, Q, P>& handlers, Logger& logger) {
     logger.trace("DSpaceResetter::run()");
     logger.trace("dimensions {nP, nQ, nD, nR} = ", xspace.dimensions().nP, xspace.dimensions().nQ,
-			xspace.dimensions().nD, rparams.size());
+                 xspace.dimensions().nD, rparams.size());
     auto solutions_proj = solutions;
     if (solution_params.empty() && !rparams.empty()) {
       logger.debug("constructing solutions");

--- a/src/molpro/linalg/itsolv/DSpaceResetter.h
+++ b/src/molpro/linalg/itsolv/DSpaceResetter.h
@@ -2,6 +2,7 @@
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_DSPACERESETTER_H
 #include <molpro/linalg/itsolv/IterativeSolver.h>
 #include <molpro/linalg/itsolv/propose_rspace.h>
+#include <molpro/linalg/itsolv/qspace_options.h>
 #include <molpro/linalg/itsolv/subspace/Dimensions.h>
 #include <molpro/linalg/itsolv/subspace/IXSpace.h>
 #include <molpro/linalg/itsolv/subspace/QSpace.h>
@@ -18,7 +19,7 @@ template <class R, class Q, class P, typename value_type>
 void resize_qspace(subspace::IXSpace<R, Q, P>& xspace, const subspace::Matrix<value_type>& solutions,
                    std::size_t max_size, Logger& logger) {
   logger.trace("resize_qspace()");
-  auto q_delete = limit_qspace_size(xspace.dimensions(), max_size, solutions, logger);
+  auto q_delete = limit_qspace_size(xspace.dimensions(), QSpaceOptions{.max_size = max_size}, solutions, logger);
   logger.debug("delete Q parameter indices = ", q_delete);
   std::sort(begin(q_delete), end(q_delete), std::greater<int>());
   for (auto iq : q_delete)

--- a/src/molpro/linalg/itsolv/DSpaceResetter.h
+++ b/src/molpro/linalg/itsolv/DSpaceResetter.h
@@ -105,7 +105,7 @@ public:
       logger.debug("constructing solutions");
       const auto dims = xspace.dimensions();
       const auto overlap = xspace.data.at(subspace::EqnData::S);
-      auto q_indices = std::vector<int>(xspace.dimensions().nQ);
+      auto q_indices = std::vector<std::size_t>(xspace.dimensions().nQ);
       std::iota(q_indices.begin(), q_indices.end(), 0);
       solutions_proj = dspace::construct_projected_solution(solutions, dims, q_indices, logger);
       auto overlap_proj =

--- a/src/molpro/linalg/itsolv/DavidsonOptions.cpp
+++ b/src/molpro/linalg/itsolv/DavidsonOptions.cpp
@@ -14,6 +14,12 @@ DavidsonOptions::DavidsonOptions(const std::map<std::string, std::string>& opt) 
   if (auto key = facet.toupper("max_size_qspace"); opt_upper.count(key)) {
     max_size_qspace = std::stoi(opt_upper.at(key));
   }
+  if (auto key = facet.toupper("min_size_qspace"); opt_upper.count(key)) {
+    min_size_qspace = std::stoi(opt_upper.at(key));
+  }
+  if (auto key = facet.toupper("contrib_thresh"); opt_upper.count(key)) {
+    contrib_thresh = std::stod(opt_upper.at(key));
+  }
   if (auto key = facet.toupper("norm_thresh"); opt_upper.count(key)) {
     norm_thresh = std::stod(opt_upper.at(key));
   }

--- a/src/molpro/linalg/itsolv/DavidsonOptions.cpp
+++ b/src/molpro/linalg/itsolv/DavidsonOptions.cpp
@@ -1,0 +1,29 @@
+#include "DavidsonOptions.h"
+#include "util.h"
+
+namespace molpro::linalg::itsolv {
+DavidsonOptions::DavidsonOptions(const std::map<std::string, std::string>& opt) {
+  auto facet = util::StringFacet{};
+  auto opt_upper = util::capitalize_keys(opt, facet);
+  if (auto key = facet.toupper("reset_D"); opt_upper.count(key)) {
+    reset_D = std::stoi(opt_upper.at(key));
+  };
+  if (auto key = facet.toupper("reset_D_max_Q_size"); opt_upper.count(key)) {
+    reset_D_max_Q_size = std::stoi(opt_upper.at(key));
+  }
+  if (auto key = facet.toupper("max_size_qspace"); opt_upper.count(key)) {
+    max_size_qspace = std::stoi(opt_upper.at(key));
+  }
+  if (auto key = facet.toupper("norm_thresh"); opt_upper.count(key)) {
+    norm_thresh = std::stod(opt_upper.at(key));
+  }
+  if (auto key = facet.toupper("svd_thresh"); opt_upper.count(key)) {
+    svd_thresh = std::stod(opt_upper.at(key));
+  }
+  if (auto key = facet.toupper("hermiticity"); opt_upper.count(key)) {
+    hermiticity = facet.tobool(opt_upper.at(key));
+  }
+}
+
+} // namespace molpro::linalg::itsolv
+

--- a/src/molpro/linalg/itsolv/DavidsonOptions.h
+++ b/src/molpro/linalg/itsolv/DavidsonOptions.h
@@ -15,6 +15,8 @@ struct DavidsonOptions {
   std::optional<std::size_t> reset_D;
   std::optional<std::size_t> reset_D_max_Q_size;
   std::optional<std::size_t> max_size_qspace;
+  std::optional<std::size_t> min_size_qspace;
+  std::optional<double> contrib_thresh;
   std::optional<double> norm_thresh;
   std::optional<double> svd_thresh;
   std::optional<bool> hermiticity;

--- a/src/molpro/linalg/itsolv/DavidsonOptions.h
+++ b/src/molpro/linalg/itsolv/DavidsonOptions.h
@@ -1,0 +1,25 @@
+#ifndef LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_DAVIDSONOPTIONS_H
+#define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_DAVIDSONOPTIONS_H
+
+#include <molpro/linalg/itsolv/options_map.h>
+
+#include <cstddef>
+#include <optional>
+
+namespace molpro::linalg::itsolv {
+
+struct DavidsonOptions {
+  DavidsonOptions() = default;
+  DavidsonOptions(const options_map& opt);
+
+  std::optional<std::size_t> reset_D;
+  std::optional<std::size_t> reset_D_max_Q_size;
+  std::optional<std::size_t> max_size_qspace;
+  std::optional<double> norm_thresh;
+  std::optional<double> svd_thresh;
+  std::optional<bool> hermiticity;
+};
+
+} // namespace molpro::linalg::itsolv
+
+#endif // LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_DAVIDSONOPTIONS_H

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
@@ -8,6 +8,7 @@
 #include <molpro/linalg/itsolv/IterativeSolverTemplate.h>
 #include <molpro/linalg/itsolv/Logger.h>
 #include <molpro/linalg/itsolv/propose_rspace.h>
+#include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/SubspaceSolverLinEig.h>
 #include <molpro/linalg/itsolv/subspace/XSpace.h>
 
@@ -66,15 +67,15 @@ public:
     auto m_prof = prof->push("itsolv::end_iteration");
     if (m_dspace_resetter.do_reset(this->m_stats->iterations, this->m_xspace->dimensions())) {
       m_resetting_in_progress = true;
-      this->m_working_set = m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
-                                                  propose_rspace_norm_thresh, propose_rspace_svd_thresh,
-                                                  *this->m_handlers, *this->m_logger);
+      this->m_working_set =
+          m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
+                                rspace_opts.norm_thresh, rspace_opts.svd_thresh, *this->m_handlers, *this->m_logger);
     } else {
       m_resetting_in_progress = false;
       prof->start("end_iteration (propose_rspace)");
-      this->m_working_set = detail::propose_rspace(
-          *this, parameters, action, *this->m_xspace, *this->m_subspace_solver, *this->m_handlers, *this->m_logger,
-          propose_rspace_svd_thresh, propose_rspace_norm_thresh, m_max_size_qspace, *this->profiler().get());
+      this->m_working_set = detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
+                                                   *this->m_handlers, *this->m_logger, rspace_opts, m_max_size_qspace,
+                                                   *this->profiler().get());
       prof->stop();
     }
     this->m_stats->iterations++;
@@ -160,9 +161,9 @@ public:
     if (opt.max_size_qspace)
       set_max_size_qspace(opt.max_size_qspace.value());
     if (opt.norm_thresh)
-      propose_rspace_norm_thresh = opt.norm_thresh.value();
+      rspace_opts.norm_thresh = opt.norm_thresh.value();
     if (opt.svd_thresh)
-      propose_rspace_svd_thresh = opt.svd_thresh.value();
+      rspace_opts.svd_thresh = opt.svd_thresh.value();
     if (opt.hermiticity)
       set_hermiticity(opt.hermiticity.value());
   }
@@ -173,17 +174,14 @@ public:
     opt->reset_D = get_reset_D();
     opt->reset_D_max_Q_size = get_reset_D_maxQ_size();
     opt->max_size_qspace = get_max_size_qspace();
-    opt->norm_thresh = propose_rspace_norm_thresh;
-    opt->svd_thresh = propose_rspace_svd_thresh;
+    opt->norm_thresh = rspace_opts.norm_thresh;
+    opt->svd_thresh = rspace_opts.svd_thresh;
     opt->hermiticity = get_hermiticity();
     return opt;
   }
 
   std::shared_ptr<Logger> logger;
-  double propose_rspace_norm_thresh = 1e-10; //!< vectors with norm less than threshold can be considered null.
-  double propose_rspace_svd_thresh = 1e-12;  //!< the smallest singular value in the subspace that can be allowed when
-                                             //!< constructing the working set. Smaller singular values will lead to
-                                             //!< deletion of parameters from the Q space
+
 protected:
   void construct_residual(const std::vector<int>& roots, const CVecRef<R>& params, const VecRef<R>& actions) override {
     auto prof = this->profiler()->push("itsolv::construct_residual");
@@ -198,6 +196,7 @@ protected:
   bool m_hermiticity = false;                              //!< whether the problem is hermitian or not
   std::vector<double> m_last_values;                       //!< The values from the previous iteration
   bool m_resetting_in_progress = false;                    //!< whether D space resetting is in progress
+  RSpaceOptions rspace_opts;                               //!< Options concerning R-space handling
 };
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
@@ -143,6 +143,8 @@ public:
     if (m_dspace_resetter.get_max_Qsize() > qspace_opts.max_size)
       m_dspace_resetter.set_max_Qsize(qspace_opts.max_size);
   }
+  std::size_t get_min_size_qspace() const { return qspace_opts.min_size; }
+  void set_min_size_qspace(std::size_t n) { qspace_opts.min_size = n; }
   void set_hermiticity(bool hermitian) override {
     m_hermiticity = hermitian;
     auto xspace = std::dynamic_pointer_cast<subspace::XSpace<R, Q, P>>(this->m_xspace);
@@ -161,6 +163,10 @@ public:
       set_reset_D_maxQ_size(opt.reset_D_max_Q_size.value());
     if (opt.max_size_qspace)
       set_max_size_qspace(opt.max_size_qspace.value());
+    if (opt.min_size_qspace)
+      set_min_size_qspace(opt.min_size_qspace.value());
+    if (opt.contrib_thresh)
+      qspace_opts.contrib_thresh = opt.contrib_thresh.value();
     if (opt.norm_thresh)
       rspace_opts.norm_thresh = opt.norm_thresh.value();
     if (opt.svd_thresh)
@@ -175,6 +181,8 @@ public:
     opt->reset_D = get_reset_D();
     opt->reset_D_max_Q_size = get_reset_D_maxQ_size();
     opt->max_size_qspace = get_max_size_qspace();
+    opt->min_size_qspace = get_min_size_qspace();
+    opt->contrib_thresh = qspace_opts.contrib_thresh;
     opt->norm_thresh = rspace_opts.norm_thresh;
     opt->svd_thresh = rspace_opts.svd_thresh;
     opt->hermiticity = get_hermiticity();

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
@@ -31,7 +31,8 @@ public:
   using typename SolverTemplate::scalar_type;
   using IterativeSolverTemplate<LinearEigensystem, R, Q, P>::report;
 
-  explicit LinearEigensystemDavidson(const std::shared_ptr<ArrayHandlers<R, Q, P>>& handlers=std::make_shared<molpro::linalg::itsolv::ArrayHandlers<R, Q, P>>(),
+  explicit LinearEigensystemDavidson(const std::shared_ptr<ArrayHandlers<R, Q, P>>& handlers =
+                                         std::make_shared<molpro::linalg::itsolv::ArrayHandlers<R, Q, P>>(),
                                      const std::shared_ptr<Logger>& logger_ = std::make_shared<Logger>())
       : SolverTemplate(std::make_shared<subspace::XSpace<R, Q, P>>(handlers, logger_),
                        std::static_pointer_cast<subspace::ISubspaceSolver<R, Q, P>>(
@@ -98,7 +99,8 @@ public:
   virtual std::vector<scalar_type> working_set_eigenvalues() const override {
     auto eval = std::vector<scalar_type>{};
     for (auto i : this->working_set()) {
-      eval.push_back(i < this->m_subspace_solver->eigenvalues().size() ? this->m_subspace_solver->eigenvalues().at(i) : 0);
+      eval.push_back(i < this->m_subspace_solver->eigenvalues().size() ? this->m_subspace_solver->eigenvalues().at(i)
+                                                                       : 0);
     }
     return eval;
   }

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidson.h
@@ -8,6 +8,7 @@
 #include <molpro/linalg/itsolv/IterativeSolverTemplate.h>
 #include <molpro/linalg/itsolv/Logger.h>
 #include <molpro/linalg/itsolv/propose_rspace.h>
+#include <molpro/linalg/itsolv/qspace_options.h>
 #include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/SubspaceSolverLinEig.h>
 #include <molpro/linalg/itsolv/subspace/XSpace.h>
@@ -73,9 +74,9 @@ public:
     } else {
       m_resetting_in_progress = false;
       prof->start("end_iteration (propose_rspace)");
-      this->m_working_set = detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
-                                                   *this->m_handlers, *this->m_logger, rspace_opts, m_max_size_qspace,
-                                                   *this->profiler().get());
+      this->m_working_set =
+          detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
+                                 *this->m_handlers, *this->m_logger, rspace_opts, qspace_opts, *this->profiler().get());
       prof->stop();
     }
     this->m_stats->iterations++;
@@ -136,11 +137,11 @@ public:
   //! Set the maximum size of Q space after resetting the D space
   void set_reset_D_maxQ_size(size_t n) { m_dspace_resetter.set_max_Qsize(n); }
   int get_reset_D_maxQ_size() const { return m_dspace_resetter.get_max_Qsize(); }
-  int get_max_size_qspace() const { return m_max_size_qspace; }
-  void set_max_size_qspace(int n) {
-    m_max_size_qspace = n;
-    if (m_dspace_resetter.get_max_Qsize() > m_max_size_qspace)
-      m_dspace_resetter.set_max_Qsize(m_max_size_qspace);
+  std::size_t get_max_size_qspace() const { return qspace_opts.max_size; }
+  void set_max_size_qspace(std::size_t n) {
+    qspace_opts.max_size = n;
+    if (m_dspace_resetter.get_max_Qsize() > qspace_opts.max_size)
+      m_dspace_resetter.set_max_Qsize(qspace_opts.max_size);
   }
   void set_hermiticity(bool hermitian) override {
     m_hermiticity = hermitian;
@@ -191,12 +192,12 @@ protected:
       this->m_handlers->rr().axpy(-eigvals.at(roots[i]), params.at(i), actions.at(i));
   }
 
-  int m_max_size_qspace = std::numeric_limits<int>::max(); //!< maximum size of Q space
-  detail::DSpaceResetter<Q> m_dspace_resetter;             //!< resets D space
-  bool m_hermiticity = false;                              //!< whether the problem is hermitian or not
-  std::vector<double> m_last_values;                       //!< The values from the previous iteration
-  bool m_resetting_in_progress = false;                    //!< whether D space resetting is in progress
-  RSpaceOptions rspace_opts;                               //!< Options concerning R-space handling
+  detail::DSpaceResetter<Q> m_dspace_resetter; //!< resets D space
+  bool m_hermiticity = false;                  //!< whether the problem is hermitian or not
+  std::vector<double> m_last_values;           //!< The values from the previous iteration
+  bool m_resetting_in_progress = false;        //!< whether D space resetting is in progress
+  RSpaceOptions rspace_opts;                   //!< Options concerning R-space handling
+  QSpaceOptions qspace_opts;                   //!< Options concerning Q-space handling
 };
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidsonOptions.cpp
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidsonOptions.cpp
@@ -1,29 +1,9 @@
 #include "LinearEigensystemDavidsonOptions.h"
-#include "util.h"
+#include "DavidsonOptions.h"
+#include "Options.h"
 
 namespace molpro::linalg::itsolv {
 LinearEigensystemDavidsonOptions::LinearEigensystemDavidsonOptions(const std::map<std::string, std::string>& opt)
-    : LinearEigensystemOptions(opt) {
-  auto facet = util::StringFacet{};
-  auto opt_upper = util::capitalize_keys(opt, facet);
-  if (auto key = facet.toupper("reset_D"); opt_upper.count(key)) {
-    reset_D = std::stoi(opt_upper.at(key));
-  };
-  if (auto key = facet.toupper("reset_D_max_Q_size"); opt_upper.count(key)) {
-    reset_D_max_Q_size = std::stoi(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("max_size_qspace"); opt_upper.count(key)) {
-    max_size_qspace = std::stoi(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("norm_thresh"); opt_upper.count(key)) {
-    norm_thresh = std::stod(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("svd_thresh"); opt_upper.count(key)) {
-    svd_thresh = std::stod(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("hermiticity"); opt_upper.count(key)) {
-    hermiticity = facet.tobool(opt_upper.at(key));
-  }
-}
+    : LinearEigensystemOptions(opt), DavidsonOptions(opt) {}
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/LinearEigensystemDavidsonOptions.h
+++ b/src/molpro/linalg/itsolv/LinearEigensystemDavidsonOptions.h
@@ -1,7 +1,9 @@
 #ifndef LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_LINEAREIGENSYSTEMDAVIDSONOPTIONS_H
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_LINEAREIGENSYSTEMDAVIDSONOPTIONS_H
 #include <molpro/linalg/itsolv/Options.h>
+#include <molpro/linalg/itsolv/DavidsonOptions.h>
 #include <molpro/linalg/itsolv/options_map.h>
+
 
 namespace molpro::linalg::itsolv {
 /*!
@@ -33,16 +35,9 @@ namespace molpro::linalg::itsolv {
  * options_p->svd_threshold.get() << std::endl;
  * @endcode
  */
-struct LinearEigensystemDavidsonOptions : public LinearEigensystemOptions {
+struct LinearEigensystemDavidsonOptions : public LinearEigensystemOptions, public DavidsonOptions {
   LinearEigensystemDavidsonOptions() = default;
   LinearEigensystemDavidsonOptions(const options_map& opt);
-
-  std::optional<int> reset_D;
-  std::optional<int> reset_D_max_Q_size;
-  std::optional<int> max_size_qspace;
-  std::optional<double> norm_thresh;
-  std::optional<double> svd_thresh;
-  std::optional<bool> hermiticity;
 };
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
@@ -4,6 +4,7 @@
 #include <molpro/linalg/itsolv/DSpaceResetter.h>
 #include <molpro/linalg/itsolv/IterativeSolverTemplate.h>
 #include <molpro/linalg/itsolv/propose_rspace.h>
+#include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/SubspaceSolverLinEig.h>
 #include <molpro/linalg/itsolv/subspace/XSpace.h>
 
@@ -60,10 +61,10 @@ public:
     auto prof = this->profiler()->push("itsolv::end_iteration");
     if (m_dspace_resetter.do_reset(this->m_stats->iterations, this->m_xspace->dimensions())) {
       this->m_working_set = m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
-                                                  m_norm_thresh, m_svd_thresh, *this->m_handlers, *this->m_logger);
+                                                  rspace_opts.norm_thresh, rspace_opts.svd_thresh, *this->m_handlers, *this->m_logger);
     } else {
       this->m_working_set = detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
-                                                   *this->m_handlers, *this->m_logger, m_svd_thresh, m_norm_thresh,
+                                                   *this->m_handlers, *this->m_logger, rspace_opts,
                                                    m_max_size_qspace, *this->profiler());
     }
     this->m_stats->iterations++;
@@ -97,12 +98,12 @@ public:
   }
 
   //! Set threshold on the norm of parameters that should be considered null
-  void set_norm_thresh(double thresh) { m_norm_thresh = thresh; }
-  double get_norm_thresh() const { return m_norm_thresh; }
+  void set_norm_thresh(double thresh) { rspace_opts.norm_thresh = thresh; }
+  double get_norm_thresh() const { return rspace_opts.norm_thresh; }
   //! Set the smallest singular value in the subspace that can be allowed when
   //! constructing the working set. Smaller singular values will lead to deletion of parameters
-  void set_svd_thresh(double thresh) { m_svd_thresh = thresh; }
-  double get_svd_thresh() const { return m_svd_thresh; }
+  void set_svd_thresh(double thresh) { rspace_opts.svd_thresh = thresh; }
+  double get_svd_thresh() const { return rspace_opts.svd_thresh; }
   //! Set the period in iterations for resetting the D space
   void set_reset_D(size_t n) { m_dspace_resetter.set_nreset(n); }
   size_t get_reset_D() const { return m_dspace_resetter.get_nreset(); }
@@ -194,8 +195,7 @@ protected:
     }
   }
 
-  double m_norm_thresh = 1e-10; //!< vectors with norm less than threshold can be considered null.
-  double m_svd_thresh = 1e-12;  //!< svd values smaller than this mark the null space
+  RSpaceOptions rspace_opts;                               //!< Options concerning R-space handling
   int m_max_size_qspace = std::numeric_limits<int>::max(); //!< maximum size of Q space
   detail::DSpaceResetter<Q> m_dspace_resetter;             //!< resets D space
   bool m_hermiticity = true;                               //!< whether the problem is hermitian or not

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
@@ -60,8 +60,9 @@ public:
   size_t end_iteration(const VecRef<R>& parameters, const VecRef<R>& action) override {
     auto prof = this->profiler()->push("itsolv::end_iteration");
     if (m_dspace_resetter.do_reset(this->m_stats->iterations, this->m_xspace->dimensions())) {
-      this->m_working_set = m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
-                                                  rspace_opts.norm_thresh, rspace_opts.svd_thresh, *this->m_handlers, *this->m_logger);
+      this->m_working_set =
+          m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
+                                rspace_opts.norm_thresh, rspace_opts.svd_thresh, *this->m_handlers, *this->m_logger);
     } else {
       this->m_working_set = detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
                                                    *this->m_handlers, *this->m_logger, rspace_opts,

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
@@ -120,6 +120,10 @@ public:
       m_dspace_resetter.set_max_Qsize(qspace_opts.max_size);
   }
   std::size_t get_max_size_qspace() const { return qspace_opts.max_size; }
+  void set_min_size_qspace(std::size_t n) {
+    qspace_opts.min_size = n;
+  }
+  std::size_t get_min_size_qspace() const { return qspace_opts.min_size; }
   void set_hermiticity(bool hermitian) override {
     m_hermiticity = hermitian;
     auto xspace = std::dynamic_pointer_cast<subspace::XSpace<R, Q, P>>(this->m_xspace);
@@ -148,6 +152,10 @@ public:
       set_reset_D_maxQ_size(opt.reset_D_max_Q_size.value());
     if (opt.max_size_qspace)
       set_max_size_qspace(opt.max_size_qspace.value());
+    if (opt.min_size_qspace)
+      set_min_size_qspace(opt.min_size_qspace.value());
+    if (opt.contrib_thresh)
+      qspace_opts.contrib_thresh = opt.contrib_thresh.value();
     if (opt.norm_thresh)
       set_norm_thresh(opt.norm_thresh.value());
     if (opt.svd_thresh)
@@ -164,6 +172,8 @@ public:
     opt->reset_D = get_reset_D();
     opt->reset_D_max_Q_size = get_reset_D_maxQ_size();
     opt->max_size_qspace = get_max_size_qspace();
+    opt->min_size_qspace = get_min_size_qspace();
+    opt->contrib_thresh = qspace_opts.contrib_thresh;
     opt->norm_thresh = get_norm_thresh();
     opt->svd_thresh = get_svd_thresh();
     opt->hermiticity = get_hermiticity();

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidson.h
@@ -4,6 +4,7 @@
 #include <molpro/linalg/itsolv/DSpaceResetter.h>
 #include <molpro/linalg/itsolv/IterativeSolverTemplate.h>
 #include <molpro/linalg/itsolv/propose_rspace.h>
+#include <molpro/linalg/itsolv/qspace_options.h>
 #include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/SubspaceSolverLinEig.h>
 #include <molpro/linalg/itsolv/subspace/XSpace.h>
@@ -64,9 +65,9 @@ public:
           m_dspace_resetter.run(parameters, *this->m_xspace, this->m_subspace_solver->solutions(),
                                 rspace_opts.norm_thresh, rspace_opts.svd_thresh, *this->m_handlers, *this->m_logger);
     } else {
-      this->m_working_set = detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
-                                                   *this->m_handlers, *this->m_logger, rspace_opts,
-                                                   m_max_size_qspace, *this->profiler());
+      this->m_working_set =
+          detail::propose_rspace(*this, parameters, action, *this->m_xspace, *this->m_subspace_solver,
+                                 *this->m_handlers, *this->m_logger, rspace_opts, qspace_opts, *this->profiler());
     }
     this->m_stats->iterations++;
     this->m_end_iteration_needed = false;
@@ -113,12 +114,12 @@ public:
   int get_reset_D_maxQ_size() const { return m_dspace_resetter.get_max_Qsize(); }
   //! Set a limit on the maximum size of Q space. This does not include the size of the working space (R) and the D
   //! space
-  void set_max_size_qspace(int n) {
-    m_max_size_qspace = n;
-    if (m_dspace_resetter.get_max_Qsize() > m_max_size_qspace)
-      m_dspace_resetter.set_max_Qsize(m_max_size_qspace);
+  void set_max_size_qspace(std::size_t n) {
+    qspace_opts.max_size = n;
+    if (m_dspace_resetter.get_max_Qsize() > qspace_opts.max_size)
+      m_dspace_resetter.set_max_Qsize(qspace_opts.max_size);
   }
-  int get_max_size_qspace() const { return m_max_size_qspace; }
+  std::size_t get_max_size_qspace() const { return qspace_opts.max_size; }
   void set_hermiticity(bool hermitian) override {
     m_hermiticity = hermitian;
     auto xspace = std::dynamic_pointer_cast<subspace::XSpace<R, Q, P>>(this->m_xspace);
@@ -196,10 +197,10 @@ protected:
     }
   }
 
-  RSpaceOptions rspace_opts;                               //!< Options concerning R-space handling
-  int m_max_size_qspace = std::numeric_limits<int>::max(); //!< maximum size of Q space
-  detail::DSpaceResetter<Q> m_dspace_resetter;             //!< resets D space
-  bool m_hermiticity = true;                               //!< whether the problem is hermitian or not
+  RSpaceOptions rspace_opts;                   //!< Options concerning R-space handling
+  QSpaceOptions qspace_opts;                   //!< Options concerning Q-space handling
+  detail::DSpaceResetter<Q> m_dspace_resetter; //!< resets D space
+  bool m_hermiticity = true;                   //!< whether the problem is hermitian or not
 };
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidsonOptions.cpp
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidsonOptions.cpp
@@ -1,29 +1,14 @@
 #include "LinearEquationsDavidsonOptions.h"
+#include "DavidsonOptions.h"
+#include "Options.h"
 #include "util.h"
 
 namespace molpro::linalg::itsolv {
 
-LinearEquationsDavidsonOptions::LinearEquationsDavidsonOptions(const options_map& opt) : LinearEquationsOptions(opt) {
+LinearEquationsDavidsonOptions::LinearEquationsDavidsonOptions(const options_map& opt)
+    : LinearEquationsOptions(opt), DavidsonOptions(opt) {
   auto facet = util::StringFacet{};
   auto opt_upper = util::capitalize_keys(opt, facet);
-  if (auto key = facet.toupper("reset_D"); opt_upper.count(key)) {
-    reset_D = std::stoi(opt_upper.at(key));
-  };
-  if (auto key = facet.toupper("reset_D_max_Q_size"); opt_upper.count(key)) {
-    reset_D_max_Q_size = std::stoi(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("max_size_qspace"); opt_upper.count(key)) {
-    max_size_qspace = std::stoi(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("norm_thresh"); opt_upper.count(key)) {
-    norm_thresh = std::stod(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("svd_thresh"); opt_upper.count(key)) {
-    svd_thresh = std::stod(opt_upper.at(key));
-  }
-  if (auto key = facet.toupper("hermiticity"); opt_upper.count(key)) {
-    hermiticity = facet.tobool(opt_upper.at(key));
-  }
   if (auto key = facet.toupper("augmented_hessian"); opt_upper.count(key)) {
     augmented_hessian = std::stod(opt_upper.at(key));
   }

--- a/src/molpro/linalg/itsolv/LinearEquationsDavidsonOptions.h
+++ b/src/molpro/linalg/itsolv/LinearEquationsDavidsonOptions.h
@@ -1,20 +1,19 @@
 #ifndef LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_LINEAREQUATIONSDAVIDSONOPTIONS_H
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_LINEAREQUATIONSDAVIDSONOPTIONS_H
+#include <molpro/linalg/itsolv/DavidsonOptions.h>
 #include <molpro/linalg/itsolv/Options.h>
+#include <molpro/linalg/itsolv/options_map.h>
+
+#include <optional>
+
 namespace molpro::linalg::itsolv {
 /*!
  * @brief Allows setting and getting of options for LinearEquationsDavidson instance via IterativeSolver base class
  */
-struct LinearEquationsDavidsonOptions : public LinearEquationsOptions {
+struct LinearEquationsDavidsonOptions : public LinearEquationsOptions, public DavidsonOptions {
   LinearEquationsDavidsonOptions() = default;
   LinearEquationsDavidsonOptions(const options_map& opt);
 
-  std::optional<int> reset_D;
-  std::optional<int> reset_D_max_Q_size;
-  std::optional<int> max_size_qspace;
-  std::optional<double> norm_thresh;
-  std::optional<double> svd_thresh;
-  std::optional<bool> hermiticity;
   std::optional<double> augmented_hessian;
 };
 

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -393,8 +393,8 @@ auto construct_dspace(const subspace::Matrix<value_type>& solutions, const subsp
   for (size_t i = 0; i < nD; ++i) {
     auto norm = std::sqrt(std::abs(handler.dot(dparams_new.at(i), dparams_new.at(i))));
     if (norm < norm_thresh) {
-      logger.warn(std::format("construct_dspace: skipping normalisation of D vector {} with near-zero norm = {:.2e}",
-                              i, norm));
+      logger.warn(
+          std::format("construct_dspace: skipping normalisation of D vector {} with near-zero norm = {:.2e}", i, norm));
       continue;
     }
     handler.scal(1. / norm, dparams_new[i]);
@@ -513,8 +513,8 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   // auto prof = profiler.push("itsolv::propose_rspace"); // FIXME two separate profilers
   auto prof = molpro::Profiler::single();
   logger.trace("itsolv::detail::propose_rspace");
-  logger.trace("dimensions {nP, nQ, nD, nW} = ", xspace.dimensions().nP, xspace.dimensions().nQ,
-		  xspace.dimensions().nD, solver.working_set().size());
+  logger.trace("dimensions {nP, nQ, nD, nW} = ", xspace.dimensions().nP, xspace.dimensions().nQ, xspace.dimensions().nD,
+               solver.working_set().size());
   profiler.start("itsolv::ISubspaceSolver::solutions");
   auto solutions = subspace_solver.solutions();
   profiler.stop();

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -15,6 +15,7 @@
 #include <molpro/profiler/Profiler.h>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <format>
 #include <functional>
@@ -322,12 +323,20 @@ std::vector<std::size_t> limit_qspace_size(const subspace::Dimensions& dims, con
 
   logger.trace("limit_qspace_size()");
 
-  if (dims.nQ <= opts.max_size) {
+  assert(opts.max_size >= opts.min_size);
+
+  const bool must_trim_size = dims.nQ > opts.max_size;
+  const bool may_trim_size = dims.nQ > opts.min_size && opts.contrib_thresh > 0;
+
+  if (!must_trim_size && !may_trim_size) {
     return {};
   }
 
+  const std::size_t min_deletions = must_trim_size ? dims.nQ - opts.max_size : 0;
+  const std::size_t max_deletions = dims.nQ - opts.min_size;
+
   std::vector<std::size_t> q_delete;
-  q_delete.reserve(dims.nQ - opts.max_size);
+  q_delete.reserve(min_deletions);
 
   const std::size_t nSol = solutions.rows();
 
@@ -348,10 +357,16 @@ std::vector<std::size_t> limit_qspace_size(const subspace::Dimensions& dims, con
   logger.trace("contribution to solutions =",
                max_contrib_to_solution | std::ranges::views::transform([](const contrib_pair& p) { return p.second; }));
 
-  for (std::size_t i = 0; i < dims.nQ - opts.max_size; ++i) {
-    auto [idx, contrib] = max_contrib_to_solution.at(i);
+  for (auto [idx, contrib] : max_contrib_to_solution) {
+    if (q_delete.size() == max_deletions || (q_delete.size() >= min_deletions && contrib >= opts.contrib_thresh)) {
+      break;
+    }
 
-    logger.debug("deleted Q vector idx, contribution = ", idx, contrib);
+    if (opts.contrib_thresh != 0 && contrib >= opts.contrib_thresh) {
+      logger.warn("deleted Q vector with max. contribution = ", contrib);
+    } else {
+      logger.debug("deleted Q vector with max. contribution = ", contrib);
+    }
 
     q_delete.emplace_back(idx);
   }

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -2,6 +2,7 @@
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_PROPOSE_RSPACE_H
 #include <molpro/linalg/itsolv/IterativeSolver.h>
 #include <molpro/linalg/itsolv/helper.h>
+#include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/Dimensions.h>
 #include <molpro/linalg/itsolv/subspace/ISubspaceSolver.h>
 #include <molpro/linalg/itsolv/subspace/IXSpace.h>
@@ -505,11 +506,11 @@ auto get_new_working_set(const std::vector<int>& working_set, const CVecRef<R>& 
  * @param residual preconditioned residuals.
  * @return number of significant parameters to calculate the action for
  */
-template <class R, class Q, class P, typename value_type_abs>
+template <class R, class Q, class P>
 auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameters, const VecRef<R>& residuals,
                     subspace::IXSpace<R, Q, P>& xspace, subspace::ISubspaceSolver<R, Q, P>& subspace_solver,
-                    ArrayHandlers<R, Q, P>& handlers, Logger& logger, value_type_abs svd_thresh,
-                    value_type_abs res_norm_thresh, int max_size_qspace, molpro::profiler::Profiler& profiler) {
+                    ArrayHandlers<R, Q, P>& handlers, Logger& logger, const RSpaceOptions& opts, int max_size_qspace,
+                    molpro::profiler::Profiler& profiler) {
   // auto prof = profiler.push("itsolv::propose_rspace"); // FIXME two separate profilers
   auto prof = molpro::Profiler::single();
   logger.trace("itsolv::detail::propose_rspace");
@@ -523,7 +524,7 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   if (!q_delete.empty()) {
     auto prof = profiler.push("construct_dspace");
     auto [dparams, dactions] =
-        construct_dspace(solutions, xspace, q_delete, res_norm_thresh, svd_thresh, handlers.qq(), logger);
+        construct_dspace(solutions, xspace, q_delete, opts.norm_thresh, opts.svd_thresh, handlers.qq(), logger);
     std::sort(begin(q_delete), end(q_delete), std::greater<int>());
     for (auto iq : q_delete)
       xspace.eraseq(iq);
@@ -552,7 +553,7 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   prof->stop();
   prof->start("redundant_indices");
   auto redundant_indices =
-      redundant_parameters(full_overlap, xspace.dimensions().nX, wresidual.size(), svd_thresh, logger);
+      redundant_parameters(full_overlap, xspace.dimensions().nX, wresidual.size(), opts.svd_thresh, logger);
   prof->stop();
   logger.debug("redundant indices = ", redundant_indices);
   util::delete_parameters(redundant_indices, wresidual);
@@ -560,7 +561,7 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   prof->start("modified_gram_schmidt");
   auto null_param_indices =
       modified_gram_schmidt(wresidual, xspace.data.at(subspace::EqnData::S), xspace.dimensions(), xspace.cparamsp(),
-                            xspace.cparamsq(), xspace.cparamsd(), res_norm_thresh, handlers, logger);
+                            xspace.cparamsq(), xspace.cparamsd(), opts.norm_thresh, handlers, logger);
   profiler.stop();
   prof->stop();
   // Now that there is SVD null_param_indices should always be empty

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -42,7 +42,7 @@ namespace dspace {
  */
 template <typename value_type>
 auto construct_projected_solution(const subspace::Matrix<value_type>& solutions, const subspace::Dimensions& dims,
-                                  const std::vector<int>& remove_qspace, Logger& logger) {
+                                  const std::vector<std::size_t>& remove_qspace, Logger& logger) {
   logger.trace("construct_projected_solution()");
   const auto nQd = remove_qspace.size();
   const auto nSol = solutions.rows();
@@ -76,8 +76,8 @@ auto construct_projected_solution(const subspace::Matrix<value_type>& solutions,
 template <typename value_type>
 auto construct_projected_solutions_overlap(const subspace::Matrix<value_type>& solutions_proj,
                                            const subspace::Matrix<value_type>& overlap,
-                                           const subspace::Dimensions& dims, const std::vector<int>& remove_qspace,
-                                           Logger& logger) {
+                                           const subspace::Dimensions& dims,
+                                           const std::vector<std::size_t>& remove_qspace, Logger& logger) {
   logger.trace("construct_projected_solution_overlap()");
   const auto nSol = solutions_proj.rows();
   const auto nQd = remove_qspace.size();
@@ -190,7 +190,7 @@ auto remove_null_projected_solutions(const subspace::Matrix<value_type>& solutio
  */
 template <typename value_type>
 auto construct_full_subspace_overlap(const subspace::Matrix<value_type>& solutions_proj,
-                                     const subspace::Dimensions& dims, const std::vector<int>& remove_qspace,
+                                     const subspace::Dimensions& dims, const std::vector<std::size_t>& remove_qspace,
                                      const subspace::Matrix<value_type>& overlap, const size_t nR) {
   const auto nDnew = solutions_proj.rows();
   const auto nQd = remove_qspace.size();
@@ -307,12 +307,12 @@ auto append_overlap_with_r(const subspace::Matrix<value_type>& overlap, const CV
  * @return q parameters marked for deletions
  */
 template <typename value_type>
-auto limit_qspace_size(const subspace::Dimensions& dims, const QSpaceOptions& opts,
-                       const subspace::Matrix<value_type>& solutions, Logger& logger) {
+std::vector<std::size_t> limit_qspace_size(const subspace::Dimensions& dims, const QSpaceOptions& opts,
+                                           const subspace::Matrix<value_type>& solutions, Logger& logger) {
   logger.trace("limit_qspace_size()");
   using value_type_abs = decltype(std::abs(solutions(0, 0)));
-  auto q_delete = std::vector<int>{};
-  auto q_indices = std::vector<int>(dims.nQ);
+  auto q_delete = std::vector<std::size_t>{};
+  auto q_indices = std::vector<std::size_t>(dims.nQ);
   std::iota(begin(q_indices), end(q_indices), 0);
   const auto nSol = solutions.rows();
   while (q_indices.size() > opts.max_size) {
@@ -346,7 +346,7 @@ auto limit_qspace_size(const subspace::Dimensions& dims, const QSpaceOptions& op
  */
 template <class R, class Q, class P, typename value_type, typename value_type_abs>
 auto construct_dspace(const subspace::Matrix<value_type>& solutions, const subspace::IXSpace<R, Q, P>& xspace,
-                      const std::vector<int>& q_delete, const value_type_abs norm_thresh,
+                      const std::vector<std::size_t>& q_delete, const value_type_abs norm_thresh,
                       const value_type_abs svd_thresh, array::ArrayHandler<Q, Q>& handler, Logger& logger) {
   const auto dims = xspace.dimensions();
   const auto overlap = xspace.data.at(subspace::EqnData::S);

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -2,6 +2,7 @@
 #define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_PROPOSE_RSPACE_H
 #include <molpro/linalg/itsolv/IterativeSolver.h>
 #include <molpro/linalg/itsolv/helper.h>
+#include <molpro/linalg/itsolv/qspace_options.h>
 #include <molpro/linalg/itsolv/rspace_options.h>
 #include <molpro/linalg/itsolv/subspace/Dimensions.h>
 #include <molpro/linalg/itsolv/subspace/ISubspaceSolver.h>
@@ -306,7 +307,7 @@ auto append_overlap_with_r(const subspace::Matrix<value_type>& overlap, const CV
  * @return q parameters marked for deletions
  */
 template <typename value_type>
-auto limit_qspace_size(const subspace::Dimensions& dims, const size_t max_size_qspace,
+auto limit_qspace_size(const subspace::Dimensions& dims, const QSpaceOptions& opts,
                        const subspace::Matrix<value_type>& solutions, Logger& logger) {
   logger.trace("limit_qspace_size()");
   using value_type_abs = decltype(std::abs(solutions(0, 0)));
@@ -314,7 +315,7 @@ auto limit_qspace_size(const subspace::Dimensions& dims, const size_t max_size_q
   auto q_indices = std::vector<int>(dims.nQ);
   std::iota(begin(q_indices), end(q_indices), 0);
   const auto nSol = solutions.rows();
-  while (q_indices.size() > max_size_qspace) {
+  while (q_indices.size() > opts.max_size) {
     auto max_contrib_to_solution = std::vector<value_type_abs>{};
     for (auto i : q_indices) {
       auto contrib = std::vector<value_type_abs>(nSol);
@@ -509,8 +510,8 @@ auto get_new_working_set(const std::vector<int>& working_set, const CVecRef<R>& 
 template <class R, class Q, class P>
 auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameters, const VecRef<R>& residuals,
                     subspace::IXSpace<R, Q, P>& xspace, subspace::ISubspaceSolver<R, Q, P>& subspace_solver,
-                    ArrayHandlers<R, Q, P>& handlers, Logger& logger, const RSpaceOptions& opts, int max_size_qspace,
-                    molpro::profiler::Profiler& profiler) {
+                    ArrayHandlers<R, Q, P>& handlers, Logger& logger, const RSpaceOptions& r_opts,
+                    const QSpaceOptions& q_opts, molpro::profiler::Profiler& profiler) {
   // auto prof = profiler.push("itsolv::propose_rspace"); // FIXME two separate profilers
   auto prof = molpro::Profiler::single();
   logger.trace("itsolv::detail::propose_rspace");
@@ -519,12 +520,12 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   profiler.start("itsolv::ISubspaceSolver::solutions");
   auto solutions = subspace_solver.solutions();
   profiler.stop();
-  auto q_delete = limit_qspace_size(xspace.dimensions(), max_size_qspace, solutions, logger);
+  auto q_delete = limit_qspace_size(xspace.dimensions(), q_opts, solutions, logger);
   logger.debug("delete Q parameter indices = ", q_delete);
   if (!q_delete.empty()) {
     auto prof = profiler.push("construct_dspace");
     auto [dparams, dactions] =
-        construct_dspace(solutions, xspace, q_delete, opts.norm_thresh, opts.svd_thresh, handlers.qq(), logger);
+        construct_dspace(solutions, xspace, q_delete, r_opts.norm_thresh, r_opts.svd_thresh, handlers.qq(), logger);
     std::sort(begin(q_delete), end(q_delete), std::greater<int>());
     for (auto iq : q_delete)
       xspace.eraseq(iq);
@@ -553,7 +554,7 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   prof->stop();
   prof->start("redundant_indices");
   auto redundant_indices =
-      redundant_parameters(full_overlap, xspace.dimensions().nX, wresidual.size(), opts.svd_thresh, logger);
+      redundant_parameters(full_overlap, xspace.dimensions().nX, wresidual.size(), r_opts.svd_thresh, logger);
   prof->stop();
   logger.debug("redundant indices = ", redundant_indices);
   util::delete_parameters(redundant_indices, wresidual);
@@ -561,7 +562,7 @@ auto propose_rspace(IterativeSolver<R, Q, P>& solver, const VecRef<R>& parameter
   prof->start("modified_gram_schmidt");
   auto null_param_indices =
       modified_gram_schmidt(wresidual, xspace.data.at(subspace::EqnData::S), xspace.dimensions(), xspace.cparamsp(),
-                            xspace.cparamsq(), xspace.cparamsd(), opts.norm_thresh, handlers, logger);
+                            xspace.cparamsq(), xspace.cparamsd(), r_opts.norm_thresh, handlers, logger);
   profiler.stop();
   prof->stop();
   // Now that there is SVD null_param_indices should always be empty

--- a/src/molpro/linalg/itsolv/propose_rspace.h
+++ b/src/molpro/linalg/itsolv/propose_rspace.h
@@ -14,7 +14,13 @@
 #include <molpro/linalg/itsolv/wrap_util.h>
 #include <molpro/profiler/Profiler.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <format>
+#include <functional>
+#include <ranges>
+#include <utility>
+#include <vector>
 
 namespace molpro::linalg::itsolv::detail {
 
@@ -309,27 +315,47 @@ auto append_overlap_with_r(const subspace::Matrix<value_type>& overlap, const CV
 template <typename value_type>
 std::vector<std::size_t> limit_qspace_size(const subspace::Dimensions& dims, const QSpaceOptions& opts,
                                            const subspace::Matrix<value_type>& solutions, Logger& logger) {
-  logger.trace("limit_qspace_size()");
   using value_type_abs = decltype(std::abs(solutions(0, 0)));
-  auto q_delete = std::vector<std::size_t>{};
-  auto q_indices = std::vector<std::size_t>(dims.nQ);
-  std::iota(begin(q_indices), end(q_indices), 0);
-  const auto nSol = solutions.rows();
-  while (q_indices.size() > opts.max_size) {
-    auto max_contrib_to_solution = std::vector<value_type_abs>{};
-    for (auto i : q_indices) {
-      auto contrib = std::vector<value_type_abs>(nSol);
-      for (size_t j = 0; j < nSol; ++j)
-        contrib[j] = std::abs(solutions(j, dims.oQ + i));
-      max_contrib_to_solution.emplace_back(*std::max_element(begin(contrib), end(contrib)));
-    }
-    auto it_min = std::min_element(begin(max_contrib_to_solution), end(max_contrib_to_solution));
-    auto i = std::distance(begin(max_contrib_to_solution), it_min);
-    q_delete.push_back(q_indices.at(i));
-    q_indices.erase(begin(q_indices) + i);
-    logger.debug("contribution to solutions =", max_contrib_to_solution);
-    logger.debug("delete Q i = ", i);
+  using contrib_pair = std::pair<std::size_t, value_type_abs>;
+  using std::begin;
+  using std::end;
+
+  logger.trace("limit_qspace_size()");
+
+  if (dims.nQ <= opts.max_size) {
+    return {};
   }
+
+  std::vector<std::size_t> q_delete;
+  q_delete.reserve(dims.nQ - opts.max_size);
+
+  const std::size_t nSol = solutions.rows();
+
+  std::vector<contrib_pair> max_contrib_to_solution;
+  max_contrib_to_solution.reserve(nSol);
+
+  for (std::size_t idx : std::ranges::views::iota(std::size_t(0), dims.nQ)) {
+    max_contrib_to_solution.emplace_back(std::make_pair(idx, value_type_abs(0)));
+
+    for (size_t j = 0; j < nSol; ++j) {
+      const value_type_abs current = std::abs(solutions(j, dims.oQ + idx));
+      max_contrib_to_solution.back().second = std::max(max_contrib_to_solution.back().second, current);
+    }
+  }
+
+  std::ranges::sort(max_contrib_to_solution, std::less<>{}, &contrib_pair::second);
+
+  logger.trace("contribution to solutions =",
+               max_contrib_to_solution | std::ranges::views::transform([](const contrib_pair& p) { return p.second; }));
+
+  for (std::size_t i = 0; i < dims.nQ - opts.max_size; ++i) {
+    auto [idx, contrib] = max_contrib_to_solution.at(i);
+
+    logger.debug("deleted Q vector idx, contribution = ", idx, contrib);
+
+    q_delete.emplace_back(idx);
+  }
+
   return q_delete;
 }
 

--- a/src/molpro/linalg/itsolv/qspace_options.h
+++ b/src/molpro/linalg/itsolv/qspace_options.h
@@ -1,0 +1,16 @@
+#ifndef LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_QSPACE_OPTIONS_H
+#define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_QSPACE_OPTIONS_H
+
+#include <cstddef>
+#include <limits>
+
+namespace molpro::linalg::itsolv {
+
+struct QSpaceOptions {
+  /// maximum size of Q space
+  std::size_t max_size = std::numeric_limits<std::size_t>::max();
+};
+
+} // namespace molpro::linalg::itsolv
+
+#endif // LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_QSPACE_OPTIONS_H

--- a/src/molpro/linalg/itsolv/qspace_options.h
+++ b/src/molpro/linalg/itsolv/qspace_options.h
@@ -9,6 +9,12 @@ namespace molpro::linalg::itsolv {
 struct QSpaceOptions {
   /// maximum size of Q space
   std::size_t max_size = std::numeric_limits<std::size_t>::max();
+  /// vectors having a smaller max. contribution to any of the current solutions
+  /// will be considered redundant
+  double contrib_thresh = 0;
+  /// minimum size of Q space - if the Q space's size would fall below this
+  /// value by deleting a vector, the deletion will be cancelled.
+  std::size_t min_size = 0;
 };
 
 } // namespace molpro::linalg::itsolv

--- a/src/molpro/linalg/itsolv/rspace_options.h
+++ b/src/molpro/linalg/itsolv/rspace_options.h
@@ -1,0 +1,17 @@
+#ifndef LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_RSPACE_OPTIONS_H
+#define LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_RSPACE_OPTIONS_H
+
+namespace molpro::linalg::itsolv {
+
+struct RSpaceOptions {
+  /// vectors with norm less than threshold can be considered null.
+  double norm_thresh = 1e-10;
+  /// the smallest singular value in the subspace that can be allowed when
+  /// constructing the working set. Smaller singular values will lead to
+  /// deletion of parameters from the Q space
+  double svd_thresh = 1e-12;
+};
+
+} // namespace molpro::linalg::itsolv
+
+#endif // LINEARALGEBRA_SRC_MOLPRO_LINALG_ITSOLV_RSPACE_OPTIONS_H


### PR DESCRIPTION
Instead of always trimming the Q-space to a pre-defined size, it is now
possible to trim the Q-space by thresholds on the maximal contribution
to solutions. That is, we can now say to drop Q-vectors if they
contribute not even than say 1e-5 to any of the solutions regardless of
the current size of the Q-space.

Also, there is now an option that specifies a minimal size for the
Q-space under which the abovementioned approach won't apply. This can be
useful to prevent too eager pruning of the Q-space.

Of course, these two new options can be combined with the existing max
Q-space option to tune Q-space handling to ones exact needs.

----

Besides this main change, this PR contains some refactorings leading up to making the actual change easy to implement.

Review note: it might be easiest to review commit-by-commit to see the individual steps of the changes